### PR TITLE
Find uses of translate pipe in pipe arguments

### DIFF
--- a/src/parsers/pipe.parser.ts
+++ b/src/parsers/pipe.parser.ts
@@ -93,12 +93,14 @@ export class PipeParser implements ParserInterface {
 			// - 'foo' | translate
 			// - (condition ? 'foo' : 'bar') | translate
 			if (ast.name === TRANSLATE_PIPE_NAME) {
-				return [ast];
+				// also visit the pipe arguments - interpolateParams object
+				return [ast, ...this.getTranslatablesFromAsts(ast.args)];
 			}
 
-			// a pipe on the outer expression, but not the translate pipe - ignore the pipe, visit the expression, e.g.:
+			// not the translate pipe - ignore the pipe, visit the expression and arguments, e.g.:
 			// - { foo: 'Hello' | translate } | json
-			return this.getTranslatablesFromAst(ast.exp);
+			// - value | date: ('mediumDate' | translate)
+			return this.getTranslatablesFromAsts([ast.exp, ...ast.args]);
 		}
 
 		// angular double curly bracket interpolation, e.g.:

--- a/src/parsers/pipe.parser.ts
+++ b/src/parsers/pipe.parser.ts
@@ -88,11 +88,17 @@ export class PipeParser implements ParserInterface {
 	}
 
 	protected getTranslatablesFromAst(ast: AST): BindingPipe[] {
-		// the entire expression is the translate pipe, e.g.:
-		// - 'foo' | translate
-		// - (condition ? 'foo' : 'bar') | translate
-		if (this.expressionIsOrHasBindingPipe(ast)) {
-			return [ast];
+		if (ast instanceof BindingPipe) {
+			// the entire expression is the translate pipe, e.g.:
+			// - 'foo' | translate
+			// - (condition ? 'foo' : 'bar') | translate
+			if (ast.name === TRANSLATE_PIPE_NAME) {
+				return [ast];
+			}
+
+			// a pipe on the outer expression, but not the translate pipe - ignore the pipe, visit the expression, e.g.:
+			// - { foo: 'Hello' | translate } | json
+			return this.getTranslatablesFromAst(ast.exp);
 		}
 
 		// angular double curly bracket interpolation, e.g.:
@@ -114,12 +120,6 @@ export class PipeParser implements ParserInterface {
 			if (ast?.left && ast?.right) {
 				return this.getTranslatablesFromAsts([ast.left, ast.right]);
 			}
-		}
-
-		// a pipe on the outer expression, but not the translate pipe - ignore the pipe, visit the expression, e.g.:
-		// - { foo: 'Hello' | translate } | json
-		if (ast instanceof BindingPipe) {
-			return this.getTranslatablesFromAst(ast.exp);
 		}
 
 		// object - ignore the keys, visit all values, e.g.:
@@ -147,16 +147,6 @@ export class PipeParser implements ParserInterface {
 
 	protected flatten<T extends AST>(array: T[][]): T[] {
 		return [].concat(...array);
-	}
-
-	protected expressionIsOrHasBindingPipe(exp: any): exp is BindingPipe {
-		if (exp.name && exp.name === TRANSLATE_PIPE_NAME) {
-			return true;
-		}
-		if (exp.exp && exp.exp instanceof BindingPipe) {
-			return this.expressionIsOrHasBindingPipe(exp.exp);
-		}
-		return false;
 	}
 
 	protected parseTemplate(template: string, path: string): TmplAstNode[] {

--- a/tests/parsers/pipe.parser.spec.ts
+++ b/tests/parsers/pipe.parser.spec.ts
@@ -196,6 +196,18 @@ describe('PipeParser', () => {
 		expect(keys).to.deep.equal([]);
 	});
 
+	it('should extract translate pipe used as pipe argument', () => {
+		const contents = `{{ value | valueToTranslationKey: ('argument' | translate) }}`;
+		const keys = parser.extract(contents, templateFilename).keys();
+		expect(keys).to.deep.equal(['argument']);
+	});
+
+	it('should extract nested uses of translate pipe', () => {
+		const contents = `{{ 'Hello' | translate: {world: ('World' | translate)} }}`;
+		const keys = parser.extract(contents, templateFilename).keys();
+		expect(keys).to.deep.equal(['Hello', 'World']);
+	});
+
 	it('should extract strings from piped arguments inside a function calls on templates', () => {
 		const contents = `{{ callMe('Hello' | translate, 'World' | translate ) }}`;
 		const keys = parser.extract(contents, templateFilename).keys();


### PR DESCRIPTION
Ported from https://github.com/biesbjerg/ngx-translate-extract/pull/243

This changes `PipeParser` to consider arguments to translate pipe and other pipes in the search for translation keys.

Examples where key did not get extracted previously:
```
{{ 'value' | testPipe: ('test1' | translate) }} // finds nothing, misses 'test1' 
{{ 'Hello' | translate: {world: ('World' | translate)} }} // finds 'Hello', misses 'World'
{{ 'previewHeader' | translate:{filename: filename || ('video' | translate)} }} // finds 'previewHeader', misses 'video'
```

Note the nested usage of translate pipe in the last example.

`expressionIsOrHasBindingPipe` has been simplified and inlined into `getTranslatablesFromAst`, the case of `'key' | foo | ... | bar | translate` is already correctly handled by another conditional branch of `getTranslatablesFromAst` and no longer needs special treatment.

Fixes part of #174 which involves pipe arguments (first example)