### PR TITLE
Bump @phenomnomnominal/tsquery to 5.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
-        "@phenomnomnominal/tsquery": "^4.1.1",
+        "@phenomnomnominal/tsquery": "^5.0.1",
         "boxen": "^6.2.1",
         "colorette": "^2.0.16",
         "flat": "^5.0.2",
@@ -346,14 +346,14 @@
       }
     },
     "node_modules/@phenomnomnominal/tsquery": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-4.2.0.tgz",
-      "integrity": "sha512-hR2U3uVcrrdkuG30ItQ+uFDs4ncZAybxWG0OjTE8ptPzVoU7GVeXpy+vMU8zX9EbmjGeITPw/su5HjYQyAH8bA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-5.0.1.tgz",
+      "integrity": "sha512-3nVv+e2FQwsW8Aw6qTU6f+1rfcJ3hrcnvH/mu9i8YhxO+9sqbOfpL8m6PbET5+xKOlz/VSbp0RoYWYCtIsnmuA==",
       "dependencies": {
-        "esquery": "^1.0.1"
+        "esquery": "^1.4.0"
       },
       "peerDependencies": {
-        "typescript": "^3 || ^4"
+        "typescript": "^3 || ^4 || ^5"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -4873,11 +4873,11 @@
       }
     },
     "@phenomnomnominal/tsquery": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-4.2.0.tgz",
-      "integrity": "sha512-hR2U3uVcrrdkuG30ItQ+uFDs4ncZAybxWG0OjTE8ptPzVoU7GVeXpy+vMU8zX9EbmjGeITPw/su5HjYQyAH8bA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-5.0.1.tgz",
+      "integrity": "sha512-3nVv+e2FQwsW8Aw6qTU6f+1rfcJ3hrcnvH/mu9i8YhxO+9sqbOfpL8m6PbET5+xKOlz/VSbp0RoYWYCtIsnmuA==",
       "requires": {
-        "esquery": "^1.0.1"
+        "esquery": "^1.4.0"
       }
     },
     "@tsconfig/node10": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint ./src/**/*.ts"
   },
   "dependencies": {
-    "@phenomnomnominal/tsquery": "^4.1.1",
+    "@phenomnomnominal/tsquery": "^5.0.1",
     "boxen": "^6.2.1",
     "colorette": "^2.0.16",
     "flat": "^5.0.2",


### PR DESCRIPTION
Support typescript 5. As far as I see this is the only library that needs to be updated.

@michaelbromley Can you have a look at this? It would be great to have a new version of ngx-translate-extract that is fully compatible with typescript 5.