### PR TITLE
fix: extract translations when service injected using inject function

### DIFF
--- a/src/utils/ast-helpers.ts
+++ b/src/utils/ast-helpers.ts
@@ -58,6 +58,7 @@ export function findClassPropertiesByType(node: ClassDeclaration, type: string):
 	return [
 		...findClassPropertiesConstructorParameterByType(node, type),
 		...findClassPropertiesDeclarationByType(node, type),
+		...findClassPropertiesDeclarationByInject(node, type),
 		...findClassPropertiesGetterByType(node, type)
 	];
 }
@@ -93,6 +94,12 @@ export function findClassPropertiesConstructorParameterByType(node: ClassDeclara
 
 export function findClassPropertiesDeclarationByType(node: ClassDeclaration, type: string): string[] {
 	const query = `PropertyDeclaration:has(TypeReference > Identifier[name="${type}"]) > Identifier`;
+	const result = tsquery<Identifier>(node, query);
+	return result.map((n) => n.text);
+}
+
+export function findClassPropertiesDeclarationByInject(node: ClassDeclaration, type: string): string[] {
+	const query = `PropertyDeclaration:has(CallExpression > Identifier[name="inject"]):has(CallExpression > Identifier[name="${type}"]) > Identifier`;
 	const result = tsquery<Identifier>(node, query);
 	return result.map((n) => n.text);
 }

--- a/tests/parsers/service.parser.spec.ts
+++ b/tests/parsers/service.parser.spec.ts
@@ -295,6 +295,20 @@ describe('ServiceParser', () => {
 		expect(keys).to.deep.equal(['Hello World']);
 	});
 
+	it('should extract strings when TranslateService is injected using the inject function ', () => {
+		const contents = `
+			export class MyComponent {
+				private translateService = inject(TranslateService);
+
+				public test() {
+					this.translateService.instant('Hello World');
+				}
+			}
+		`;
+		const keys = parser.extract(contents, componentFilename)?.keys();
+		expect(keys).to.deep.equal(['Hello World']);
+	});
+
 	it('should extract strings passed to TranslateServices methods only', () => {
 		const contents = `
 			export class AppComponent implements OnInit {


### PR DESCRIPTION
If `TranslateService` was injected using the `inject` function without an explicit type annotation for the property, the translations were not getting properly extracted. For example:

```ts
export class MyComponent {
	private translateService = inject(TranslateService);

	public test() {
		this.translateService.instant('Hello World');
	}
}
```