### PR TITLE
chore: update tsconfig target and module to es2022

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -25,12 +25,14 @@ const y = yargs().option('patterns', {
 	describe: 'Default patterns',
 	type: 'array',
 	default: ['/**/*.html', '/**/*.ts'],
+	// eslint-disable-next-line id-denylist
+	string: true,
 	hidden: true
 });
 
-const parsed = y.parse() as any; // temporary any
+const parsed = await y.parse();
 
-export const cli: any = y // temporary any
+const cli = await y
 	.usage('Extract strings from files for translation.\nUsage: $0 [options]')
 	.version(process.env.npm_package_version)
 	.alias('version', 'v')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,12 +5,12 @@
         "noImplicitThis": true,
         "removeComments": true,
         "declaration": true,
-        "target": "es2020",
+        "target": "es2022",
         "lib": [
-            "es2020",
+            "es2022",
             "dom"
         ],
-        "module": "es2020",
+        "module": "es2022",
         "esModuleInterop": true,
         "moduleResolution": "node",
         "outDir": "dist",


### PR DESCRIPTION
This enables the option to use top level await and is also aligned with the latest angular tsconfig target