### PR TITLE
fix(pipe.parser): `RangeError: Maximum call stack size exceeded` on nested templates

### DIFF
--- a/tests/parsers/pipe.parser.spec.ts
+++ b/tests/parsers/pipe.parser.spec.ts
@@ -369,5 +369,18 @@ describe('PipeParser', () => {
 				'else.block'
 			]);
 		});
+
+		it('should handle ast with arbitrary depth without hitting the call stack limit', () => {
+			const depth = 500;
+			const contents = `
+				${Array(depth).fill('<i>').join('')}
+					{{ 'deep' | translate }}
+				${Array(depth).fill('</i>').join('')}
+			`;
+
+			const keys = parser.extract(contents, templateFilename)?.keys();
+			expect(contents).to.contain('<i><i><i><i><i><i>');
+			expect(keys).to.deep.equal(['deep']);
+		});
 	});
 });


### PR DESCRIPTION
Thank you so much for maintaining this project!

With https://github.com/vendure-ecommerce/ngx-translate-extract/pull/27 we get the exception `RangeError: Maximum call stack size exceeded` on some templates. The `findPipesInNode => extractPipesFromChildNodes => findPipesInNode` recursion on a class fails on depth 18, e.g. this template:

```html
<i><i><i><i><i><i><i><i><i><i><i><i><i><i><i><i><i><i>
    {{ 'deep' | translate }}
</i></i></i></i></i></i></i></i></i></i></i></i></i></i></i></i></i></i>
```

Which apparently can happen if you dabble with some nested diffs, forms, bootstrap boilerplate, angular blocks and some ternary to finish it off.

This PR cleans up the recursion via two traversal methods that don't hold much context, allowing to traverse through nested templates (from before depth 18 to ~700 in this PR).