### PR TITLE
feat: add an optional cache that speeds up consecutive runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ Useful when loading multiple translation files in the same application and prefi
 ngx-translate-extract --input ./src --output ./src/i18n/{da,en}.json --strip-prefix 'PREFIX.'
 ```
 
+**Cache for consecutive runs**
+
+If your project grows rather large, runs can take seconds. With this cache, unchanged files don't need
+to be parsed again, keeping consecutive runs under .5 seconds.
+
+```bash
+ngx-translate-extract --cache-file node_modules/.i18n-cache/my-cache-file --input ./src --output ./src/i18n/{da,en}.json
+```
+
 ### JSON indentation
 
 Tabs are used by default for indentation when saving extracted strings in json formats:
@@ -117,6 +126,7 @@ Options:
                  multiple paths                                               [array] [required] [default: ["./"]]
   --output, -o   Paths where you would like to save extracted strings. You can use path expansion, glob
                  patterns and multiple paths                                                    [array] [required]
+  --cache-file   Cache parse results to speed up consecutive runs                                         [string]
   --marker, -m   Custom marker function name                                                              [string]
 
 Examples:

--- a/src/cache/cache-interface.ts
+++ b/src/cache/cache-interface.ts
@@ -1,0 +1,4 @@
+export interface CacheInterface<RESULT extends object = object> {
+	persist(): void;
+	get<KEY extends string>(uniqueContents: KEY, generator: () => RESULT): RESULT;
+}

--- a/src/cache/file-cache.ts
+++ b/src/cache/file-cache.ts
@@ -1,0 +1,84 @@
+import type { CacheInterface } from './cache-interface.js';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const getHash = (value: string) => crypto.createHash('sha256').update(value).digest('hex');
+
+export class FileCache<RESULT extends object = object> implements CacheInterface<RESULT> {
+	private tapped: Record<string, RESULT> = {};
+	private cached?: Readonly<Record<string, RESULT>> = undefined;
+	private originalCache?: string;
+	private versionHash?: string;
+
+	constructor(private cacheFile: string) {}
+
+	public get<KEY extends string>(uniqueContents: KEY, generator: () => RESULT): RESULT {
+		if (!this.cached) {
+			this.readCache();
+			this.versionHash = this.getVersionHash();
+		}
+
+		const key = getHash(`${this.versionHash}${uniqueContents}`);
+
+		if (key in this.cached) {
+			this.tapped[key] = this.cached[key];
+
+			return this.cached[key];
+		}
+
+		return (this.tapped[key] = generator());
+	}
+
+	public persist(): void {
+		const newCache = JSON.stringify(this.sortByKey(this.tapped), null, 2);
+		if (newCache === this.originalCache) {
+			return;
+		}
+
+		const file = this.getCacheFile();
+		const dir = path.dirname(file);
+
+		const stats = fs.statSync(dir, { throwIfNoEntry: false });
+		if (!stats) {
+			fs.mkdirSync(dir);
+		}
+
+		const tmpFile = `${file}~${getHash(newCache)}`;
+
+		fs.writeFileSync(tmpFile, newCache, { encoding: 'utf-8' });
+		fs.rmSync(file, { force: true, recursive: false });
+		fs.renameSync(tmpFile, file);
+	}
+
+	private sortByKey(unordered: Record<string, RESULT>): Record<string, RESULT> {
+		return Object.keys(unordered)
+			.sort()
+			.reduce((obj, key) => {
+				obj[key] = unordered[key];
+				return obj;
+			}, {} as Record<string, RESULT>);
+	}
+
+	private readCache(): void {
+		try {
+			this.originalCache = fs.readFileSync(this.getCacheFile(), { encoding: 'utf-8' });
+			this.cached = JSON.parse(this.originalCache) ?? {};
+		} catch {
+			this.originalCache = undefined;
+			this.cached = {};
+		}
+	}
+
+	private getVersionHash(): string {
+		const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+		const packageJson = fs.readFileSync(path.join(projectRoot, 'package.json'), { encoding: 'utf-8' });
+
+		return getHash(packageJson);
+	}
+
+	private getCacheFile(): string {
+		return `${this.cacheFile}-ngx-translate-extract-cache.json`;
+	}
+}

--- a/src/cache/null-cache.ts
+++ b/src/cache/null-cache.ts
@@ -1,0 +1,8 @@
+import { CacheInterface } from './cache-interface.js';
+
+export class NullCache<RESULT extends object = object> implements CacheInterface<RESULT> {
+	persist() {}
+	get<KEY extends string>(_uniqueContents: KEY, generator: () => RESULT): RESULT {
+		return generator();
+	}
+}

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -18,6 +18,8 @@ import { StripPrefixPostProcessor } from '../post-processors/strip-prefix.post-p
 import { CompilerInterface } from '../compilers/compiler.interface.js';
 import { CompilerFactory } from '../compilers/compiler.factory.js';
 import { normalizePaths } from '../utils/fs-helpers.js';
+import { FileCache } from '../cache/file-cache.js';
+import { TranslationType } from '../utils/translation.collection.js';
 
 // First parsing pass to be able to access pattern argument for use input/output arguments
 const y = yargs().option('patterns', {
@@ -83,6 +85,10 @@ const cli = await y
 		describe: 'Remove obsolete strings after merge',
 		type: 'boolean'
 	})
+	.option('cache-file', {
+		describe: 'Cache parse results to speed up consecutive runs',
+		type: 'string'
+	})
 	.option('marker', {
 		alias: 'm',
 		describe: 'Name of a custom marker function for extracting strings',
@@ -138,6 +144,10 @@ if (cli.marker) {
 	parsers.push(new MarkerParser());
 }
 extractTask.setParsers(parsers);
+
+if (cli.cacheFile) {
+	extractTask.setCache(new FileCache<TranslationType[]>(cli.cacheFile));
+}
 
 // Post processors
 const postProcessors: PostProcessorInterface[] = [];


### PR DESCRIPTION
used like: 
```sh
ngx-translate-extract --cache-file node_modules/.i18n-cache/my-cache-file --input ./src --output ./src/i18n/{da,en}.json
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

In our project with 1100 scanned files, cached runs go down from 2 seconds to 0.3 seconds. And the terminal is less spamy as it only reports changed files.

The cache is implemented as careful as possible:
* opt-in, so disabled by default (you need to provide `--cache-file` option)
* the only thing that is cached is: "filename + contents" => "parser result"
* removes entries from cache that were unused, to not let stale data linger
* invalidate cache if package.json changes (aka new ngx-translate-extract release)
* the globbing/search for files isn't cached, the extractor still looks at the entire project from scratch

But even if you don't use the cache, uncached is faster as well, as the `.union` calls that I removed shaved off half a second as well for us.

A cached run looks like this:
![CleanShot 2024-02-02 at 14 55 20@2x](https://github.com/vendure-ecommerce/ngx-translate-extract/assets/905328/5ac4425d-376e-4de2-8e45-d629ec5303a2)
