### PR TITLE
fix: Fix marker function parsing when used after bracket syntax casting expression

### DIFF
--- a/src/parsers/marker.parser.ts
+++ b/src/parsers/marker.parser.ts
@@ -1,4 +1,5 @@
-import { tsquery } from '@phenomnomnominal/tsquery';
+import { ScriptKind, tsquery } from '@phenomnomnominal/tsquery';
+import { extname } from 'path';
 
 import { ParserInterface } from './parser.interface.js';
 import { TranslationCollection } from '../utils/translation.collection.js';
@@ -9,7 +10,16 @@ const MARKER_IMPORT_NAME = 'marker';
 
 export class MarkerParser implements ParserInterface {
 	public extract(source: string, filePath: string): TranslationCollection | null {
-		const sourceFile = tsquery.ast(source, filePath);
+		const supportedScriptTypes: Record<string, ScriptKind> = {
+			'.js': ScriptKind.JS,
+			'.jsx': ScriptKind.JSX,
+			'.ts': ScriptKind.TS,
+			'.tsx': ScriptKind.TSX
+		};
+
+		const scriptKind = supportedScriptTypes[extname(filePath)] ?? ScriptKind.TS;
+
+		const sourceFile = tsquery.ast(source, filePath, scriptKind);
 
 		const markerImportName = getNamedImportAlias(sourceFile, MARKER_MODULE_NAME, MARKER_IMPORT_NAME);
 		if (!markerImportName) {

--- a/tests/parsers/marker.parser.spec.ts
+++ b/tests/parsers/marker.parser.spec.ts
@@ -71,4 +71,20 @@ describe('MarkerParser', () => {
 		const keys = parser.extract(contents, componentFilename).keys();
 		expect(keys).to.deep.equal(['Hello world']);
 	});
+
+	it('should not break after bracket syntax casting', () => {
+		const contents = `
+		import { marker } from '@colsen1991/ngx-translate-extract-marker';
+		
+		marker('hello');
+		const input: unknown = 'hello';    
+		const myNiceVar1 = input as string;
+		marker('hello.after.as.syntax');
+			
+		const myNiceVar2 = <string>input;
+		marker('hello.after.bracket.syntax');
+		`;
+		const keys = parser.extract(contents, componentFilename).keys();
+		expect(keys).to.deep.equal(['hello', 'hello.after.as.syntax', 'hello.after.bracket.syntax']);
+	});
 });


### PR DESCRIPTION
The issue is that the `tsquery.ast` defaults to parsing the source as TSX, which causes problems when bracket syntax casting (`<Type>`) is used. This is because the parser confuses the casting syntax with JSX. To resolve this, we need to explicitly set the ScriptKind parameter to TS.

In the `ast` function description is also suggested to use `ScriptKind.TS` if the code uses the `<Type>` syntax for casting.

> "If you are using the `<Type>` syntax for casting, you should use `ScriptKind.TS`."
https://github.com/phenomnomnominal/tsquery/blob/master/src/ast.ts#L12

This change ensures that the parser passes the correct `ScriptKind` to the `ast` function based on the source file extension, so that for .ts files it avoids the confusion with JSX and preventing parsing errors.

Fixes #43