### PR TITLE
fix: Fix service parser to recognize the `TranslateService` property from an aliased superclass

### DIFF
--- a/src/parsers/marker.parser.ts
+++ b/src/parsers/marker.parser.ts
@@ -9,7 +9,7 @@ export class MarkerParser implements ParserInterface {
 	public extract(source: string, filePath: string): TranslationCollection | null {
 		const sourceFile = getAST(source, filePath);
 
-		const markerImportName = getNamedImportAlias(sourceFile, MARKER_MODULE_NAME, MARKER_IMPORT_NAME);
+		const markerImportName = getNamedImportAlias(sourceFile, MARKER_IMPORT_NAME, new RegExp(MARKER_MODULE_NAME));
 		if (!markerImportName) {
 			return null;
 		}

--- a/src/parsers/service.parser.ts
+++ b/src/parsers/service.parser.ts
@@ -19,7 +19,8 @@ import {
 	getImportPath,
 	findFunctionExpressions,
 	findVariableNameByInjectType,
-	getAST
+	getAST,
+	getNamedImport
 } from '../utils/ast-helpers.js';
 
 const TRANSLATE_SERVICE_TYPE_REFERENCE = 'TranslateService';
@@ -86,17 +87,20 @@ export class ServiceParser implements ParserInterface {
 	}
 
 	private findParentClassProperties(classDeclaration: ClassDeclaration, ast: SourceFile): string[] {
-		const superClassName = getSuperClassName(classDeclaration);
-		if (!superClassName) {
+		const superClassNameOrAlias = getSuperClassName(classDeclaration);
+		if (!superClassNameOrAlias) {
 			return [];
 		}
-		const importPath = getImportPath(ast, superClassName);
+
+		const importPath = getImportPath(ast, superClassNameOrAlias);
 		if (!importPath) {
 			// parent class must be in the same file and will be handled automatically, so we can
 			// skip it here
 			return [];
 		}
 
+		// Resolve the actual name of the superclass from the named import
+		const superClassName = getNamedImport(ast, superClassNameOrAlias, importPath);
 		const currDir = path.join(path.dirname(ast.fileName), '/');
 
 		const key = `${currDir}|${importPath}`;

--- a/tests/parsers/service.parser.spec.ts
+++ b/tests/parsers/service.parser.spec.ts
@@ -435,6 +435,31 @@ describe('ServiceParser', () => {
 		expect(keys).to.deep.equal(['test']);
 	});
 
+	it('should recognize the property from an aliased base class imported from a different file', () => {
+		const baseFileContent = `
+			export abstract class Base {
+				protected translate: TranslateService;
+			}
+		`;
+
+		const testFileContent = `
+			import { Base as CoreBase } from './src/base';
+
+			export class Test extends CoreBase {
+				public constructor() {
+					super();
+					this.translate.instant("test");
+				}
+			}
+		`;
+
+		fs.mkdirSync(path.join(tempDir, 'src'), { recursive: true });
+		fs.writeFileSync(path.join(tempDir, 'src', 'base.ts'), baseFileContent);
+
+		const keys = parser.extract(testFileContent, path.join(tempDir, 'test.ts'))?.keys();
+		expect(keys).to.deep.equal(['test']);
+	});
+
 	it('should work with getters in base classes', () => {
 		const file_contents_base = `
 			export abstract class Base {


### PR DESCRIPTION
Fixes #52