### PR TITLE
fix: extract translations when service is used via inline-injection

### DIFF
--- a/src/utils/ast-helpers.ts
+++ b/src/utils/ast-helpers.ts
@@ -142,7 +142,7 @@ export function findMethodCallExpressions(node: Node, propName: string, fnName: 
 
 	const fnNameRegex = functionNames.join('|');
 
-	const query = `CallExpression > PropertyAccessExpression:has(Identifier[name=/^(${fnNameRegex})$/]):has(PropertyAccessExpression:has(Identifier[name="${propName}"]):not(:has(ThisKeyword)))`;
+	const query = `CallExpression > PropertyAccessExpression:has(Identifier[name=/^(${fnNameRegex})$/]):has(PropertyAccessExpression:has(Identifier[name="${propName}"]):not(:has(ThisKeyword)), CallExpression:has(Identifier[name="inject"]))`;
 
 	return tsquery(node, query)
 		.filter((n) => functionNames.includes(n.getLastToken().getText()))

--- a/tests/parsers/service.parser.spec.ts
+++ b/tests/parsers/service.parser.spec.ts
@@ -787,5 +787,15 @@ describe('ServiceParser', () => {
 			const keys = parser.extract(contents, componentFilename)?.keys();
 			expect(keys).to.deep.equal(['child.a.title', 'grandchild.a1.title']);
 		});
+
+		it('should extract strings when inline injection is used', () => {
+			const contents = `
+				export const getTitle = (): string => {
+					return inject(TranslateService).instant('translation.key');
+				}
+			`;
+			const keys = parser.extract(contents, componentFilename)?.keys();
+			expect(keys).to.deep.equal(['translation.key']);
+		});
 	});
 });


### PR DESCRIPTION
When injecting the `TranslateService` and directly accessing its methods, in such cases the translations were not properly extracted.

An example of a case that previously failed:

```ts
export const getTitle = (): string => {
	return inject(TranslateService).instant('translation.key');
}
```