### PR TITLE
fix: prevent overwriting of existing translations in namespaced-json format

### DIFF
--- a/src/compilers/namespaced-json.compiler.ts
+++ b/src/compilers/namespaced-json.compiler.ts
@@ -18,7 +18,7 @@ export class NamespacedJsonCompiler implements CompilerInterface {
 	public compile(collection: TranslationCollection): string {
 		const values = unflatten(
 			collection.toKeyValueObject(),
-			{object: true}
+			{object: true, overwrite: true}
 		);
 		return JSON.stringify(values, null, this.indentation);
 	}

--- a/tests/cli/__snapshots__/cli.spec.ts.snap
+++ b/tests/cli/__snapshots__/cli.spec.ts.snap
@@ -20,6 +20,52 @@ exports[`CLI Integration Tests > extracts translation keys to a .json file 1`] =
 }"
 `;
 
+exports[`CLI Integration Tests > extracts translation keys to a .json file with namespaced-json format 1`] = `
+"{
+	"translate-service": {
+		"comp": {
+			"welcome": "",
+			"description": "",
+			"details": "",
+			"show-more-label": "",
+			"show-less-label": ""
+		}
+	},
+	"pipe": {
+		"comp": {
+			"welcome": "",
+			"description": ""
+		}
+	},
+	"directive": {
+		"comp": {
+			"welcome": "",
+			"description": ""
+		}
+	},
+	"private-translate-service": {
+		"comp": {
+			"welcome": "",
+			"description": ""
+		}
+	},
+	"ngx-translate": {
+		"marker": {
+			"dashboard": {
+				"title": "",
+				"description": ""
+			}
+		}
+	},
+	"marker": {
+		"dashboard": {
+			"title": "",
+			"description": ""
+		}
+	}
+}"
+`;
+
 exports[`CLI Integration Tests > extracts translation keys to a .po file 1`] = `
 "msgid ""
 msgstr ""

--- a/tests/cli/cli.spec.ts
+++ b/tests/cli/cli.spec.ts
@@ -55,6 +55,15 @@ describe.concurrent('CLI Integration Tests', () => {
 		expect(extracted).toMatchSnapshot();
 	});
 
+	test('extracts translation keys to a .json file with namespaced-json format', async ({ expect }) => {
+		const OUTPUT_FILE = createUniqueFileName('strings.json');
+		await execAsync(`node ${CLI_PATH} --input ${FIXTURES_PATH} --output ${OUTPUT_FILE} --format=namespaced-json`);
+
+		const extracted = await readFile(OUTPUT_FILE, { encoding: 'utf8' });
+
+		expect(extracted).toMatchSnapshot();
+	});
+
 	test('extracts translation keys to multiple files', async ({ expect, task }) => {
 		const OUTPUT_PATH = resolve(TMP_PATH, task.id);
 		const OUTPUT_PATTERN = resolve(OUTPUT_PATH, '{en,fr}.json');

--- a/tests/compilers/namespaced-json.compiler.spec.ts
+++ b/tests/compilers/namespaced-json.compiler.spec.ts
@@ -51,6 +51,50 @@ describe('NamespacedJsonCompiler', () => {
 		expect(result).to.equal('{\n\t"NAMESPACE": {\n\t\t"KEY": {\n\t\t\t"FIRST_KEY": "",\n\t\t\t"SECOND_KEY": "VALUE"\n\t\t}\n\t}\n}');
 	});
 
+	it('should correctly unflatten when base key has empty value and nested keys exist', () => {
+		const collection = new TranslationCollection({
+			NAMESPACE: { value: '', sourceFiles: [] },
+			'NAMESPACE.FIRST_KEY': { value: 'FIRST_KEY_VALUE', sourceFiles: [] },
+			'NAMESPACE.SECOND_KEY': { value: 'SECOND_KEY_VALUE', sourceFiles: [] },
+		});
+		const result: string = compiler.compile(collection);
+		expect(result).to.equal(
+			// prettier-ignore
+			'{\n' +
+				'\t"NAMESPACE": {\n' +
+				'\t\t"FIRST_KEY": "FIRST_KEY_VALUE",\n' +
+				'\t\t"SECOND_KEY": "SECOND_KEY_VALUE"\n' +
+			'\t}\n' +
+			'}',
+		);
+	});
+
+	it('should NOT overwrite existing entries', () => {
+		const translations = JSON.stringify({
+			NAMESPACE: {
+				FIRST_KEY: 'FIRST_KEY_VALUE',
+				SECOND_KEY: 'SECOND_KEY_VALUE',
+			},
+		});
+		const newTranslations = JSON.stringify({
+			NAMESPACE: '',
+		});
+		const existing = compiler.parse(translations);
+		const extracted = compiler.parse(newTranslations);
+
+		const combined = extracted.union(existing);
+		const result = compiler.compile(combined);
+		expect(result).to.equal(
+			// prettier-ignore
+			'{\n' +
+			'\t"NAMESPACE": {\n' +
+			'\t\t"FIRST_KEY": "FIRST_KEY_VALUE",\n' +
+			'\t\t"SECOND_KEY": "SECOND_KEY_VALUE"\n' +
+			'\t}\n' +
+			'}',
+		);
+	});
+
 	it('should preserve numeric values on compile', () => {
 		const collection = new TranslationCollection({
 			'option.0': {value: '', sourceFiles: []},


### PR DESCRIPTION
fixes the issue where an extracted namespace would remove all nested keys of an existing translation

Closes #78