### PR TITLE
fix(pipe-parser): fix key extraction from translate pipe within logical expressions

### DIFF
--- a/src/parsers/pipe.parser.ts
+++ b/src/parsers/pipe.parser.ts
@@ -141,6 +141,13 @@ export class PipeParser implements ParserInterface {
 			ret.push(...this.parseTranslationKeysFromPipe(pipeContent.exp));
 		} else if (pipeContent instanceof ParenthesizedExpression) {
 			ret.push(...this.parseTranslationKeysFromPipe(pipeContent.expression));
+		} else if (this.isLogicalOrNullishCoalescingExpression(pipeContent)) {
+			if (pipeContent.left instanceof LiteralPrimitive) {
+				ret.push(`${pipeContent.left.value}`);
+			}
+			if (pipeContent.right instanceof LiteralPrimitive) {
+				ret.push(`${pipeContent.right.value}`);
+			}
 		}
 		return ret;
 	}
@@ -228,5 +235,13 @@ export class PipeParser implements ParserInterface {
 
 	protected parseTemplate(template: string, path: string): TmplAstNode[] {
 		return parseTemplate(template, path).nodes;
+	}
+
+	/** Checks whether a Binary node uses a logical (&&, ||) or nullish coalescing (??) operator. */
+	protected isLogicalOrNullishCoalescingExpression(expr: unknown): expr is Binary {
+		return (
+			expr instanceof Binary &&
+			(expr.operation === '&&' || expr.operation === '||' || expr.operation === '??')
+		);
 	}
 }

--- a/tests/parsers/pipe.parser.spec.ts
+++ b/tests/parsers/pipe.parser.spec.ts
@@ -304,6 +304,36 @@ describe('PipeParser', () => {
 		expect(keys).to.deep.equal([`Hello`, `World`]);
 	});
 
+	it('should extract key from translate pipe inside `AND` expressions', () => {
+		const singleCondition = `<div>{{ someProp() && 'translation.key' | translate }}</div>`;
+		const singleConditionKeys = parser.extract(singleCondition, templateFilename).keys();
+		expect(singleConditionKeys).to.deep.equal(['translation.key']);
+
+		const multipleConditions = `<div>{{ someProp() && anotherProp() && 'translation.key' | translate }}</div>`;
+		const multipleConditionKeys = parser.extract(multipleConditions, templateFilename).keys();
+		expect(multipleConditionKeys).to.deep.equal(['translation.key']);
+	});
+
+	it('should extract key from translate pipe inside `OR` expressions', () => {
+		const singleCondition = `<div>{{ someProp() || 'translation.key' | translate }}</div>`;
+		const singleConditionKeys = parser.extract(singleCondition, templateFilename).keys();
+		expect(singleConditionKeys).to.deep.equal(['translation.key']);
+
+		const multipleConditions = `<div>{{ someProp() || anotherProp() || 'translation.key' | translate }}</div>`;
+		const multipleConditionKeys = parser.extract(multipleConditions, templateFilename).keys();
+		expect(multipleConditionKeys).to.deep.equal(['translation.key']);
+	});
+
+	it('should extract key from translate pipe inside nullish coalescing expressions', () => {
+		const singleCondition = `<div>{{ someProp() ?? 'translation.key' | translate }}</div>`;
+		const singleConditionKeys = parser.extract(singleCondition, templateFilename).keys();
+		expect(singleConditionKeys).to.deep.equal(['translation.key']);
+
+		const multipleConditions = `<div>{{ someProp() ?? anotherProp() ?? 'translation.key' | translate }}</div>`;
+		const multipleConditionKeys = parser.extract(multipleConditions, templateFilename).keys();
+		expect(multipleConditionKeys).to.deep.equal(['translation.key']);
+	});
+
 	describe('Built-in control flow', () => {
 		it('should extract keys from elements inside an @if/@else block', () => {
 			const contents = `


### PR DESCRIPTION
Addresses cases where the `translate` pipe is used after logical (&&, ||) or nullish coalescing (??) operators in Angular templates. These keys were previously missed by the parser.

Closes: #94