### PR TITLE
fix: package.json not found since 10.0 when using `--cache-file`

### DIFF
--- a/src/cache/file-cache.ts
+++ b/src/cache/file-cache.ts
@@ -72,7 +72,7 @@ export class FileCache<RESULT extends object = object> implements CacheInterface
 	}
 
 	private getVersionHash(): string {
-		const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+		const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 		const packageJson = fs.readFileSync(path.join(projectRoot, 'package.json'), { encoding: 'utf-8' });
 
 		return getHash(packageJson);


### PR DESCRIPTION
this PR fixes that you see an error `node_modules/@vendure/package.json not found` when using `ngx-translate-extract` with the `--cache-file` option from https://github.com/vendure-ecommerce/ngx-translate-extract/pull/38

instead use the same environment variable used in https://github.com/vendure-ecommerce/ngx-translate-extract/blob/152b6491ae72cbdbc5b7655486f7fe8192dbf839/src/cli/cli.ts#L39
