### PR TITLE
fix(cli): fix version resolution for the `--version` option

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -36,7 +36,7 @@ const parsed = await y.parse();
 
 const cli = await y
 	.usage('Extract strings from files for translation.\nUsage: $0 [options]')
-	.version(process.env.npm_package_version)
+	.version()
 	.alias('version', 'v')
 	.help('help')
 	.alias('help', 'h')

--- a/tests/cli/cli.spec.ts
+++ b/tests/cli/cli.spec.ts
@@ -12,7 +12,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPOSITORY_ROOT = resolve(__dirname, '../..');
 const FIXTURES_PATH = resolve(REPOSITORY_ROOT, 'tests/cli/fixtures/');
 const TMP_PATH = resolve(REPOSITORY_ROOT, 'tests/cli/tmp');
-const CLI_PATH = resolve(TMP_PATH, 'dist/cli/cli.js');
+const CLI_PATH = resolve(TMP_PATH, 'dist/cli.js');
 
 let nextFileId = 0;
 const createUniqueFileName = (fileName: string) => resolve(TMP_PATH, `${nextFileId++}-${fileName}`);
@@ -30,6 +30,13 @@ describe.concurrent('CLI Integration Tests', () => {
 	afterAll(async () => {
 		await rm(TMP_PATH, { recursive: true });
 	});
+
+	test('shows the version', async ({expect}) => {
+		const packageJson = JSON.parse(await readFile(resolve(REPOSITORY_ROOT, 'package.json'), 'utf8'));
+		const { stdout } = await execAsync(`node ${CLI_PATH} --version`);
+
+		expect(stdout.trim()).toBe(packageJson.version);
+	})
 
 	test('shows the expected output when extracting', async ({expect}) => {
 		const OUTPUT_FILE = createUniqueFileName('strings.json');


### PR DESCRIPTION
`yargs` parses the `package.json` of the module and use its version value automatically when there is no explicit version passed to `.version()`

Closes #97