### PR TITLE
fix: exclude empty strings from extracted keys

### DIFF
--- a/src/parsers/pipe.parser.ts
+++ b/src/parsers/pipe.parser.ts
@@ -91,6 +91,9 @@ export class PipeParser implements ParserInterface {
 
 		pipes.forEach((pipe) => {
 			this.parseTranslationKeysFromPipe(pipe).forEach((key) => {
+				if (key === '') {
+					return;
+				}
 				collection = collection.add(key, '', filePath);
 			});
 		});

--- a/src/utils/ast-helpers.ts
+++ b/src/utils/ast-helpers.ts
@@ -213,7 +213,7 @@ export function findPropertyCallExpressions(node: Node, prop: string, fnName: st
 }
 
 export function getStringsFromExpression(expression: Expression): string[] {
-	if (isStringLiteralLike(expression)) {
+	if (isStringLiteralLike(expression) && expression.text !== '') {
 		return [expression.text];
 	}
 

--- a/tests/parsers/pipe.parser.spec.ts
+++ b/tests/parsers/pipe.parser.spec.ts
@@ -334,6 +334,13 @@ describe('PipeParser', () => {
 		expect(multipleConditionKeys).to.deep.equal(['translation.key']);
 	});
 
+	it('should not extract empty strings as keys', () => {
+		const contents = `<div>{{ '' | translate }}</div>`;
+		const keys = parser.extract(contents, templateFilename).keys();
+
+		expect(keys).toEqual([]);
+	});
+
 	describe('Built-in control flow', () => {
 		it('should extract keys from elements inside an @if/@else block', () => {
 			const contents = `

--- a/tests/parsers/service.parser.spec.ts
+++ b/tests/parsers/service.parser.spec.ts
@@ -170,6 +170,24 @@ describe('ServiceParser', () => {
 		expect(keys).to.deep.equal(['Hello', 'World']);
 	});
 
+	it('should NOT extract empty strings from the get()/instant()/stream() methods', () => {
+		const contents = `
+			@Component({ })
+			export class AppComponent {
+				public constructor(protected _translateService: TranslateService) { }
+				public test() {
+					this._translateService.get('');
+					this._translateService.instant('');
+					this._translateService.stream('');
+					this._translateService.get(['', '']);
+					this._translateService.instant(['', '']);
+					this._translateService.stream(['', '']);
+				}
+		`;
+		const keys = parser.extract(contents, componentFilename)?.keys();
+		expect(keys).to.deep.equal([]);
+	});
+
 	it('should not extract strings in get()/instant()/stream() methods of other services', () => {
 		const contents = `
 			@Component({ })


### PR DESCRIPTION
Align extractor behavior with `ngx-translate`, which does not treat empty strings as valid translation keys.

Closes #105