### PR TITLE
fix(pipe-parser): detect keys inside template literals

### DIFF
--- a/src/parsers/pipe.parser.ts
+++ b/src/parsers/pipe.parser.ts
@@ -18,6 +18,7 @@ import {
 	KeyedRead,
 	ASTWithSource,
 	ParenthesizedExpression,
+	TemplateLiteral,
 } from '@angular/compiler';
 
 import { getAST, getNodesFromSwitchBlockTmpl } from '../utils/ast-helpers.js';
@@ -228,6 +229,10 @@ export class PipeParser implements ParserInterface {
 
 		if (ast instanceof ParenthesizedExpression) {
 			return this.getTranslatablesFromAsts([ast.expression]);
+		}
+
+		if (ast instanceof TemplateLiteral) {
+			return this.getTranslatablesFromAsts(ast.expressions);
 		}
 
 		return [];

--- a/tests/parsers/pipe.parser.spec.ts
+++ b/tests/parsers/pipe.parser.spec.ts
@@ -334,6 +334,12 @@ describe('PipeParser', () => {
 		expect(multipleConditionKeys).to.deep.equal(['translation.key']);
 	});
 
+	it('should extract key from translate pipe inside template literals', () => {
+		const contents = "<div>{{ `${'translation.key' | translate}, ${'another.key' | translate}` }}</div>";
+		const keys = parser.extract(contents, templateFilename).keys();
+		expect(keys).to.deep.equal(['translation.key', 'another.key']);
+	});
+
 	it('should not extract empty strings as keys', () => {
 		const contents = `<div>{{ '' | translate }}</div>`;
 		const keys = parser.extract(contents, templateFilename).keys();


### PR DESCRIPTION
support extracting translation keys from translate pipe usages in template string literals:

```ts
`${'translation.key' | translate}`
```

This is a bit of an edge case, since you'd normally pass arguments to the translate pipe instead. 

I've stumbled upon this after enabling [`@angular-eslint/template/prefer-template-literal`](https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin-template/docs/rules/prefer-template-literal.md) in a project, only to find out some of the translation keys got flagged as unused and removed.