### PR TITLE
feat: add support for the new `translate` function and method from `ngx-translate` 18

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -9,6 +9,7 @@ import { MarkerParser } from '../parsers/marker.parser.js';
 import { ParserInterface } from '../parsers/parser.interface.js';
 import { PipeParser } from '../parsers/pipe.parser.js';
 import { ServiceParser } from '../parsers/service.parser.js';
+import { TranslateFunctionParser } from '../parsers/translate-function.parser.js';
 import { KeyAsDefaultValuePostProcessor } from '../post-processors/key-as-default-value.post-processor.js';
 import { KeyAsInitialDefaultValuePostProcessor } from '../post-processors/key-as-initial-default-value.post-processor.js';
 import { NullAsDefaultValuePostProcessor } from '../post-processors/null-as-default-value.post-processor.js';
@@ -176,7 +177,7 @@ const extractTask = new ExtractTask(cli.input, cli.output, {
 });
 
 // Parsers
-const parsers: ParserInterface[] = [new PipeParser(), new DirectiveParser(), new ServiceParser()];
+const parsers: ParserInterface[] = [new PipeParser(), new DirectiveParser(), new ServiceParser(), new TranslateFunctionParser()];
 if (cli.marker) {
 	parsers.push(new FunctionParser(cli.marker));
 } else {

--- a/src/parsers/service.parser.ts
+++ b/src/parsers/service.parser.ts
@@ -23,7 +23,7 @@ import { TranslationCollection } from '../utils/translation.collection.js';
 import { ParserInterface } from './parser.interface.js';
 
 const TRANSLATE_SERVICE_TYPE_REFERENCE = 'TranslateService';
-const TRANSLATE_SERVICE_METHOD_NAMES = ['get', 'instant', 'stream'];
+const TRANSLATE_SERVICE_METHOD_NAMES = ['get', 'instant', 'stream', 'translate'];
 
 export class ServiceParser implements ParserInterface {
 	private static propertyMap = new Map<string, string[]>();

--- a/src/parsers/translate-function.parser.ts
+++ b/src/parsers/translate-function.parser.ts
@@ -1,0 +1,28 @@
+import { getNamedImportAlias, findFunctionCallExpressions, getStringsFromExpression, getAST } from '../utils/ast-helpers.js';
+import { TranslationCollection } from '../utils/translation.collection.js';
+import { ParserInterface } from './parser.interface.js';
+
+export class TranslateFunctionParser implements ParserInterface {
+	public extract(source: string, filePath: string): TranslationCollection {
+		let collection = new TranslationCollection();
+		const sourceFile = getAST(source, filePath).parsedFile;
+
+		const translateFnImportName = getNamedImportAlias(sourceFile, 'translate', '@ngx-translate/core');
+		if (!translateFnImportName) {
+			return collection;
+		}
+
+		const callExpressions = findFunctionCallExpressions(sourceFile, translateFnImportName);
+
+		callExpressions.forEach((callExpression) => {
+			const [firstArg] = callExpression.arguments;
+			if (!firstArg) {
+				return;
+			}
+			const strings = getStringsFromExpression(firstArg);
+			collection = collection.addKeys(strings, filePath);
+		});
+
+		return collection;
+	}
+}

--- a/src/utils/ast-helpers.ts
+++ b/src/utils/ast-helpers.ts
@@ -301,7 +301,7 @@ export function findPropertyCallExpressions(node: Node, prop: string, fnName: st
 }
 
 export function getStringsFromExpression(expression: Expression): string[] {
-	if (isStringLiteralLike(expression) && expression.text !== '') {
+	if (isStringLiteralLike(expression) && expression.text.trim() !== '') {
 		return [expression.text];
 	}
 

--- a/tests/cli/__snapshots__/cli.spec.ts.snap
+++ b/tests/cli/__snapshots__/cli.spec.ts.snap
@@ -2,11 +2,11 @@
 
 exports[`CLI Integration Tests > extracts translation keys to a .json file 1`] = `
 "{
-	"translate-service.comp.welcome": "",
 	"translate-service.comp.description": "",
 	"translate-service.comp.details": "",
 	"translate-service.comp.show-more-label": "",
 	"translate-service.comp.show-less-label": "",
+	"translate-service.comp.welcome": "",
 	"pipe.comp.welcome": "",
 	"pipe.comp.description": "",
 	"directive.comp.welcome": "",
@@ -24,11 +24,11 @@ exports[`CLI Integration Tests > extracts translation keys to a .json file with 
 "{
 	"translate-service": {
 		"comp": {
-			"welcome": "",
 			"description": "",
 			"details": "",
 			"show-more-label": "",
-			"show-less-label": ""
+			"show-less-label": "",
+			"welcome": ""
 		}
 	},
 	"pipe": {
@@ -74,10 +74,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\\n"
 
 #: ngx-translate-extract/tests/cli/fixtures/translate-service.component.fixture.ts
-msgid "translate-service.comp.welcome"
-msgstr ""
-
-#: ngx-translate-extract/tests/cli/fixtures/translate-service.component.fixture.ts
 msgid "translate-service.comp.description"
 msgstr ""
 
@@ -91,6 +87,10 @@ msgstr ""
 
 #: ngx-translate-extract/tests/cli/fixtures/translate-service.component.fixture.ts
 msgid "translate-service.comp.show-less-label"
+msgstr ""
+
+#: ngx-translate-extract/tests/cli/fixtures/translate-service.component.fixture.ts
+msgid "translate-service.comp.welcome"
 msgstr ""
 
 #: ngx-translate-extract/tests/cli/fixtures/translate-pipe.component.fixture.ts
@@ -142,9 +142,6 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\\n"
 "Content-Transfer-Encoding: 8bit\\n"
 
-msgid "translate-service.comp.welcome"
-msgstr ""
-
 msgid "translate-service.comp.description"
 msgstr ""
 
@@ -155,6 +152,9 @@ msgid "translate-service.comp.show-more-label"
 msgstr ""
 
 msgid "translate-service.comp.show-less-label"
+msgstr ""
+
+msgid "translate-service.comp.welcome"
 msgstr ""
 
 msgid "pipe.comp.welcome"

--- a/tests/cli/fixtures/translate-service.component.fixture.ts
+++ b/tests/cli/fixtures/translate-service.component.fixture.ts
@@ -1,5 +1,5 @@
-import { Component } from '@angular/core';
-import { TranslateService } from '@ngx-translate/core';
+import { Component, inject, signal } from '@angular/core';
+import { translate, TranslateService } from '@ngx-translate/core';
 
 @Component({
 	selector: 'app-home',
@@ -21,11 +21,11 @@ import { TranslateService } from '@ngx-translate/core';
 export class TranslateServiceComponentFixture {
 	private readonly translate = inject(TranslateService);
 
-	readonly welcomeMessage = this.translate.instant('translate-service.comp.welcome');
+	readonly welcomeMessage = translate('translate-service.comp.welcome');
 	readonly descriptionMessage = this.translate.instant('translate-service.comp.description');
-	readonly detailsMessage = this.translate.instant('translate-service.comp.details');
-	readonly showMoreLabel = this.translate.instant('translate-service.comp.show-more-label');
-	readonly showLessLabel = this.translate.instant('translate-service.comp.show-less-label');
+	readonly detailsMessage = this.translate.get('translate-service.comp.details');
+	readonly showMoreLabel = this.translate.stream('translate-service.comp.show-more-label');
+	readonly showLessLabel = this.translate.translate('translate-service.comp.show-less-label');
 
 	readonly showMore = signal(false);
 }

--- a/tests/parsers/service.parser.spec.ts
+++ b/tests/parsers/service.parser.spec.ts
@@ -168,6 +168,24 @@ describe('ServiceParser', () => {
 		expect(key).to.deep.equal(['Hello', 'World']);
 	});
 
+	it("should extract array of strings in TranslateService's translate() method", () => {
+		const contents = `
+			@Component({ })
+			export class AppComponent {
+			    private readonly _translateService = inject(TranslateService)
+
+				constructor(protected ) {
+					this._translateService.translate('hello.from.constructor');
+				}
+				test() {
+					this._translateService.translate(['Hello', 'World']);
+				}
+			}
+		`;
+		const key = parser.extract(contents, componentFilename)?.keys();
+		expect(key).to.deep.equal(['hello.from.constructor', 'Hello', 'World']);
+	});
+
 	it('should extract string arrays encapsulated in backticks', () => {
 		const contents = `
 			@Component({ })
@@ -182,7 +200,7 @@ describe('ServiceParser', () => {
 		expect(keys).to.deep.equal(['Hello', 'World']);
 	});
 
-	it('should NOT extract empty strings from the get()/instant()/stream() methods', () => {
+	it('should NOT extract empty strings from the get()/instant()/stream()/translate() methods', () => {
 		const contents = `
 			@Component({ })
 			export class AppComponent {
@@ -191,16 +209,19 @@ describe('ServiceParser', () => {
 					this._translateService.get('');
 					this._translateService.instant('');
 					this._translateService.stream('');
+					this._translateService.translate('');
 					this._translateService.get(['', '']);
 					this._translateService.instant(['', '']);
 					this._translateService.stream(['', '']);
+					this._translateService.translate(['', '']);
 				}
+			}
 		`;
 		const keys = parser.extract(contents, componentFilename)?.keys();
 		expect(keys).to.deep.equal([]);
 	});
 
-	it('should not extract strings in get()/instant()/stream() methods of other services', () => {
+	it('should not extract strings in get()/instant()/stream()/translate() methods of other services', () => {
 		const contents = `
 			@Component({ })
 			export class AppComponent {
@@ -212,7 +233,9 @@ describe('ServiceParser', () => {
 					this._otherService.get('Hello World');
 					this._otherService.instant('Hi there');
 					this._otherService.stream('Hi there');
+					this._otherService.translate('Hi there');
 				}
+			}
 		`;
 		const keys = parser.extract(contents, componentFilename)?.keys();
 		expect(keys).to.deep.equal([]);
@@ -866,9 +889,18 @@ describe('ServiceParser', () => {
 				export const getTitle = (): string => {
 					return inject(TranslateService).instant('translation.key');
 				}
+				export const getSubtitle = (): string => {
+					return inject(TranslateService).get('translation.get.key');
+				}
+				export const getDescription = (): string => {
+					return inject(TranslateService).stream('translation.stream.key');
+				}
+				export const getLabel = (): string => {
+					return inject(TranslateService).translate('translation.translate.key');
+				}
 			`;
 			const keys = parser.extract(contents, componentFilename)?.keys();
-			expect(keys).to.deep.equal(['translation.key']);
+			expect(keys).to.deep.equal(['translation.key', 'translation.get.key', 'translation.stream.key', 'translation.translate.key']);
 		});
 
 		it('should ignore injected services that are not TranslateService type', () => {

--- a/tests/parsers/translate-function.parser.spec.ts
+++ b/tests/parsers/translate-function.parser.spec.ts
@@ -1,0 +1,252 @@
+import { describe, beforeEach, expect, it } from 'vitest';
+
+import { TranslateFunctionParser } from '../../src/parsers/translate-function.parser.js';
+
+describe('TranslateFnParser', () => {
+	const componentFilename: string = 'test.component.ts';
+
+	let parser: TranslateFunctionParser;
+
+	beforeEach(() => {
+		parser = new TranslateFunctionParser();
+	});
+
+	describe('class property initializers', () => {
+		it('should extract keys from class property initializers', () => {
+			const contents = `
+			import { translate } from '@ngx-translate/core';
+
+			@Component({ template: '' })
+			export class App {
+				greeting = translate('hello');
+				farewell = translate('goodbye');
+			}
+		`;
+			const keys = parser.extract(contents, componentFilename).keys();
+			expect(keys).to.deep.equal(['hello', 'goodbye']);
+		});
+
+		it('should extract array of keys from class property initializer', () => {
+			const contents = `
+			import { translate } from '@ngx-translate/core';
+
+			@Component({ template: '' })
+			export class App {
+				labels = translate(['yes', 'no', 'cancel']);
+			}
+		`;
+			const keys = parser.extract(contents, componentFilename).keys();
+			expect(keys).to.deep.equal(['yes', 'no', 'cancel']);
+		});
+
+		it('should extract key and ignore params argument', () => {
+			const contents = `
+			import { translate } from '@ngx-translate/core';
+
+			@Component({ template: '' })
+			export class App {
+				greeting = translate('hello', { name: 'John' });
+			}
+		`;
+			const keys = parser.extract(contents, componentFilename).keys();
+			expect(keys).to.deep.equal(['hello']);
+		});
+
+		it('should not extract key when class property receives a signal as key', () => {
+			const contents = `
+			import { translate } from '@ngx-translate/core';
+
+			@Component({ template: '' })
+			export class App {
+				keySignal = signal('hello');
+				dynamic = translate(this.keySignal);
+			}
+		`;
+			const keys = parser.extract(contents, componentFilename).keys();
+			expect(keys).to.deep.equal([]);
+		});
+
+		it('should not extract key when class property receives an arrow function as key', () => {
+			const contents = `
+			import { translate } from '@ngx-translate/core';
+
+			@Component({ template: '' })
+			export class App {
+				model = signal({ key: 'hello' });
+				dynamic = translate(() => this.model().key);
+			}
+		`;
+			const keys = parser.extract(contents, componentFilename).keys();
+			expect(keys).to.deep.equal([]);
+		});
+
+		it('should extract split string keys from class property initializers', () => {
+			const contents = `
+			import { translate } from '@ngx-translate/core';
+
+			@Component({ template: '' })
+			export class App {
+				label = translate('very.' + 'long.' + 'key');
+			}
+		`;
+			const keys = parser.extract(contents, componentFilename).keys();
+			expect(keys).to.deep.equal(['very.long.key']);
+		});
+	});
+
+	describe('constructor', () => {
+		it('should extract keys from constructor', () => {
+			const contents = `
+			import { translate } from '@ngx-translate/core';
+
+			@Component({ template: '' })
+			export class App {
+				readonly staticLabel: string;
+				readonly label: string;
+
+				constructor() {
+					this.staticLabel = translate('hello')();
+					this.label = translate('word');
+				}
+			}
+		`;
+			const keys = parser.extract(contents, componentFilename).keys();
+			expect(keys).to.deep.equal(['hello', 'word']);
+		});
+
+		it('should extract keys from constructor with binary expression', () => {
+			const contents = `
+			import { translate } from '@ngx-translate/core';
+
+			@Component({ template: '' })
+			export class App {
+				constructor() {
+					translate(condition || 'fallback.key');
+				}
+			}
+		`;
+			const keys = parser.extract(contents, componentFilename).keys();
+			expect(keys).to.deep.equal(['fallback.key']);
+		});
+
+		it('should extract keys from constructor with ternary expression', () => {
+			const contents = `
+			import { translate } from '@ngx-translate/core';
+
+			@Component({ template: '' })
+			export class App {
+				constructor() {
+					translate(condition ? 'key.true' : 'key.false');
+				}
+			}
+		`;
+			const keys = parser.extract(contents, componentFilename).keys();
+			expect(keys).to.deep.equal(['key.true', 'key.false']);
+		});
+	});
+
+	describe('runInInjectionContext', () => {
+		it('should extract keys used inside runInInjectionContext', () => {
+			const contents = `
+			import { translate } from '@ngx-translate/core';
+
+			runInInjectionContext(injector, () => {
+				const greeting = translate('hello');
+				const farewell = translate('goodbye');
+			});
+		`;
+			const keys = parser.extract(contents, componentFilename).keys();
+			expect(keys).to.deep.equal(['hello', 'goodbye']);
+		});
+	});
+
+	describe('Import variations', () => {
+		it('should extract keys when translate is imported with an alias', () => {
+			const contents = `
+			import { translate as _ } from '@ngx-translate/core';
+
+			@Component({ template: '' })
+			export class App {
+				greeting = _('hello');
+			}
+		`;
+			const keys = parser.extract(contents, componentFilename).keys();
+			expect(keys).to.deep.equal(['hello']);
+		});
+
+		it('should not extract keys when translate is not imported from @ngx-translate/core', () => {
+			const contents = `
+			import { translate } from './translate-wrapper';
+
+			@Component({ template: '' })
+			export class App {
+				greeting = translate('hello');
+			}
+		`;
+			const keys = parser.extract(contents, componentFilename).keys();
+			expect(keys).to.deep.equal([]);
+		});
+
+		it('should not extract keys when there is no import', () => {
+			const contents = `
+			@Component({ template: '' })
+			export class App {
+				greeting = translate('hello');
+			}
+		`;
+			const keys = parser.extract(contents, componentFilename).keys();
+			expect(keys).to.deep.equal([]);
+		});
+	});
+
+	describe('edge cases', () => {
+		it('should not extract empty or whitespace-only string keys', () => {
+			const contents = `
+			import { translate } from '@ngx-translate/core';
+
+			@Component({ template: '' })
+			export class App {
+				empty = translate('');
+				whitespace = translate('   ');
+			}
+		`;
+			const keys = parser.extract(contents, componentFilename).keys();
+			expect(keys).to.deep.equal([]);
+		});
+
+		it('should not extract template literal keys with expressions', () => {
+			const contents = `
+			import { translate } from '@ngx-translate/core';
+
+			@Component({ template: '' })
+			export class App {
+				dynamic = translate(\`HELLO.\${this.name}\`);
+			}
+		`;
+			const keys = parser.extract(contents, componentFilename).keys();
+			expect(keys).to.deep.equal([]);
+		});
+
+		it('should not break after bracket syntax casting', () => {
+			const contents = `
+			import { translate } from '@ngx-translate/core';
+
+			@Component({ template: '' })
+			export class App {
+				label: string;
+
+				constructor() {
+					const input: unknown = 'hello';
+					const myNiceVar1 = input as string;
+					translate('hello.after.as.syntax');
+
+					const myNiceVar2 = <string>input;
+					translate('hello.after.bracket.syntax');
+				}
+			}
+		`;
+			const keys = parser.extract(contents, componentFilename).keys();
+			expect(keys).to.deep.equal(['hello.after.as.syntax', 'hello.after.bracket.syntax']);
+		});
+	});
+});


### PR DESCRIPTION
Closes #142

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/ngx-translate-extract/pr/143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->