### PR TITLE
refactor: update parsers to always return a collection instead of null

### DIFF
--- a/src/cli/tasks/extract.task.ts
+++ b/src/cli/tasks/extract.task.ts
@@ -129,9 +129,9 @@ export class ExtractTask implements TaskInterface {
 					return this.parsers
 						.map((parser) => {
 							const extracted = parser.extract(contents, filePath);
-							return extracted instanceof TranslationCollection ? extracted.values : undefined;
+							return extracted.values;
 						})
-						.filter((result): result is TranslationType => !!result && !!Object.keys(result).length);
+						.filter((result) => Object.keys(result).length > 0);
 				});
 
 				collectionTypes.push(...cachedCollectionValues);

--- a/src/parsers/directive.parser.ts
+++ b/src/parsers/directive.parser.ts
@@ -8,7 +8,6 @@ import {
 	LiteralArray,
 	LiteralMap,
 	LiteralPrimitive,
-	parseTemplate,
 	TmplAstBoundAttribute as BoundAttribute,
 	TmplAstElement as Element,
 	TmplAstNode as Node,
@@ -41,13 +40,12 @@ export const TRANSLATE_ATTR_NAMES = ['translate', 'marker'];
 type ElementLike = Element | Template;
 
 export class DirectiveParser implements ParserInterface {
-	public extract(source: string, filePath: string): TranslationCollection | null {
+	public extract(source: string, filePath: string): TranslationCollection {
 		let collection: TranslationCollection = new TranslationCollection();
-
 		const parsedTemplates = getAST(source, filePath).parsedTemplates;
 
 		if (parsedTemplates.length === 0) {
-			return null;
+			return collection;
 		}
 
 		const nodes: TmplAstNode[] = parsedTemplates.map((parsedTpl) => parsedTpl.nodes).flat();
@@ -240,14 +238,5 @@ export class DirectiveParser implements ParserInterface {
 	 */
 	protected isText(node: Node): node is Text {
 		return node instanceof Text;
-	}
-
-	/**
-	 * Parse a template into nodes
-	 * @param template
-	 * @param path
-	 */
-	protected parseTemplate(template: string, path: string): Node[] {
-		return parseTemplate(template, path).nodes;
 	}
 }

--- a/src/parsers/function.parser.ts
+++ b/src/parsers/function.parser.ts
@@ -8,14 +8,13 @@ const { isIdentifier } = pkg;
 export class FunctionParser implements ParserInterface {
 	constructor(private fnName: string) {}
 
-	public extract(source: string, filePath: string): TranslationCollection | null {
+	public extract(source: string, filePath: string): TranslationCollection {
+		let collection: TranslationCollection = new TranslationCollection();
 		const sourceFile = getAST(source, filePath).parsedFile;
 
 		if (!sourceFile) {
-			return null;
+			return collection;
 		}
-
-		let collection: TranslationCollection = new TranslationCollection();
 
 		const callExpressions = findSimpleCallExpressions(sourceFile, this.fnName);
 		callExpressions.forEach((callExpression) => {

--- a/src/parsers/marker.parser.ts
+++ b/src/parsers/marker.parser.ts
@@ -10,19 +10,18 @@ const NGX_TRANSLATE_MARKER_MODULE_NAME = '@ngx-translate/core';
 const NGX_TRANSLATE_MARKER_IMPORT_NAME = '_';
 
 export class MarkerParser implements ParserInterface {
-	public extract(source: string, filePath: string): TranslationCollection | null {
+	public extract(source: string, filePath: string): TranslationCollection {
+		let collection = new TranslationCollection();
 		const sourceFile = getAST(source, filePath).parsedFile;
 
 		if (!sourceFile) {
-			return null;
+			return collection;
 		}
 
 		const markerImportName = this.getMarkerImportNameFromSource(sourceFile);
 		if (!markerImportName) {
-			return null;
+			return collection;
 		}
-
-		let collection: TranslationCollection = new TranslationCollection();
 
 		const callExpressions = findFunctionCallExpressions(sourceFile, markerImportName);
 		callExpressions.forEach((callExpression) => {

--- a/src/parsers/parser.interface.ts
+++ b/src/parsers/parser.interface.ts
@@ -1,5 +1,5 @@
 import { TranslationCollection } from '../utils/translation.collection.js';
 
 export interface ParserInterface {
-	extract(source: string, filePath: string): TranslationCollection | null;
+	extract(source: string, filePath: string): TranslationCollection;
 }

--- a/src/parsers/service.parser.ts
+++ b/src/parsers/service.parser.ts
@@ -28,21 +28,20 @@ const TRANSLATE_SERVICE_METHOD_NAMES = ['get', 'instant', 'stream', 'translate']
 export class ServiceParser implements ParserInterface {
 	private static propertyMap = new Map<string, string[]>();
 
-	public extract(source: string, filePath: string): TranslationCollection | null {
+	public extract(source: string, filePath: string): TranslationCollection {
+		let collection = new TranslationCollection();
 		const sourceFile = getAST(source, filePath).parsedFile;
 
 		if (!sourceFile) {
-			return null;
+			return collection;
 		}
 
 		const classDeclarations = findClassDeclarations(sourceFile);
 		const functionDeclarations = findFunctionExpressions(sourceFile);
 
-		if (!classDeclarations && !functionDeclarations) {
-			return null;
+		if (classDeclarations.length === 0 && functionDeclarations.length === 0) {
+			return collection;
 		}
-
-		let collection: TranslationCollection = new TranslationCollection();
 
 		const translateServiceCallExpressions: CallExpression[] = [];
 


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/ngx-translate-extract/pr/145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782410213&installation_id=128408429&pr_number=145&repository=vendurehq%2Fngx-translate-extract&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fngx-translate-extract%2Fpull%2F145&signature=e9c48fb179352797cc9b84828b8b2182e88d05b9ab925702c97f1a0bcf31286b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->