### PR TITLE
refactor(po-compiler): improve compile performance and fix header detection

### DIFF
--- a/src/compilers/po.compiler.ts
+++ b/src/compilers/po.compiler.ts
@@ -1,7 +1,9 @@
-import { po } from 'gettext-parser';
+import { type GetTextTranslation, type GetTextTranslations, po } from 'gettext-parser';
 
-import { TranslationCollection, TranslationInterface, TranslationType } from '../utils/translation.collection.js';
-import { CompilerInterface, CompilerOptions } from './compiler.interface.js';
+import { TranslationCollection, type TranslationType } from '../utils/translation.collection.js';
+import { type CompilerInterface, type CompilerOptions } from './compiler.interface.js';
+
+const GETTEXT_HEADER_ENTRY_MSGID = '';
 
 export class PoCompiler implements CompilerInterface {
 	public extension: string = 'po';
@@ -19,7 +21,22 @@ export class PoCompiler implements CompilerInterface {
 	}
 
 	public compile(collection: TranslationCollection): string {
-		const data = {
+		const translations: Record<string, GetTextTranslation> = Object.create(null);
+
+		for (const [key, entry] of Object.entries(collection.values)) {
+			const translation: GetTextTranslation = {
+				msgid: key,
+				msgstr: entry.value !== null ? [entry.value] : [''], // PO format does not support null values, empty string is used instead
+			};
+
+			if (this.includeSources) {
+				translation.comments = { reference: entry.sourceFiles.join('\n') };
+			}
+
+			translations[key] = translation;
+		}
+
+		const data: GetTextTranslations = {
 			charset: 'utf-8',
 			headers: {
 				'mime-version': '1.0',
@@ -27,18 +44,7 @@ export class PoCompiler implements CompilerInterface {
 				'content-transfer-encoding': '8bit',
 			},
 			translations: {
-				[this.domain]: Object.keys(collection.values).reduce((translations, key) => {
-					const entry: TranslationInterface = collection.get(key);
-					const comments = this.includeSources ? { reference: entry.sourceFiles?.join('\n') } : undefined;
-					return {
-						...translations,
-						[key]: {
-							msgid: key,
-							msgstr: entry.value,
-							comments: comments,
-						},
-					};
-				}, {}),
+				[this.domain]: translations,
 			},
 		};
 
@@ -56,7 +62,7 @@ export class PoCompiler implements CompilerInterface {
 		const translationEntries = Object.entries(poTranslations);
 		const convertedTranslations: TranslationType = {};
 		for (const [msgid, message] of translationEntries) {
-			if (msgid === this.domain) {
+			if (msgid === GETTEXT_HEADER_ENTRY_MSGID) {
 				continue;
 			}
 


### PR DESCRIPTION
- Replace reduce+spread with linear loop for building translations
- Wrap `msgstr` in array and handle `null` values per PO spec
- Compare msgid against `GETTEXT_HEADER_ENTRY_MSGID` instead of domain
- Add stronger typing

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/ngx-translate-extract/pr/146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782677142&installation_id=128408429&pr_number=146&repository=vendurehq%2Fngx-translate-extract&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fngx-translate-extract%2Fpull%2F146&signature=7e1628b23b5633bc385ecfdf5a8057dc6487a6dda6d73aaf603fe47f9c1ed0ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->