### PR TITLE
fix(cli): warn that pot format does not support `--null-as-default-vallue`

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -18,7 +18,7 @@ import { PurgeObsoleteKeysPostProcessor } from '../post-processors/purge-obsolet
 import { SortByKeyPostProcessor } from '../post-processors/sort-by-key.post-processor.js';
 import { StringAsDefaultValuePostProcessor } from '../post-processors/string-as-default-value.post-processor.js';
 import { StripPrefixPostProcessor } from '../post-processors/strip-prefix.post-processor.js';
-import { green, red } from '../utils/cli-color.js';
+import { green, red, yellow } from '../utils/cli-color.js';
 import { normalizePaths } from '../utils/fs-helpers.js';
 import { TranslationType } from '../utils/translation.collection.js';
 import { ExtractTask } from './tasks/extract.task.js';
@@ -201,7 +201,7 @@ if (cli.keyAsDefaultValue) {
 	postProcessors.push(new KeyAsDefaultValuePostProcessor());
 } else if (cli.keyAsInitialDefaultValue) {
 	postProcessors.push(new KeyAsInitialDefaultValuePostProcessor());
-} else if (cli.nullAsDefaultValue) {
+} else if (cli.nullAsDefaultValue && cli.format !== CompilerType.Pot) {
 	postProcessors.push(new NullAsDefaultValuePostProcessor());
 } else if (cli.stringAsDefaultValue) {
 	postProcessors.push(new StringAsDefaultValuePostProcessor({ defaultValue: cli.stringAsDefaultValue as string }));
@@ -227,6 +227,9 @@ extractTask.setCompiler(compiler);
 // Run task
 try {
 	extractTask.execute();
+	if (cli.nullAsDefaultValue && cli.format === CompilerType.Pot) {
+		console.log(yellow(`\nWARNING: POT format does not support --null-as-default-value.`));
+	}
 	console.log(green('\nDone.\n'));
 	process.exit(0);
 } catch (e) {

--- a/src/utils/cli-color.ts
+++ b/src/utils/cli-color.ts
@@ -1,6 +1,7 @@
 import { styleText } from 'node:util';
 
 export const cyan = (text: string) => styleText('cyan', text);
+export const yellow = (text: string) => styleText('yellow', text);
 export const green = (text: string) => styleText('green', text);
 export const bold = (text: string) => styleText('bold', text);
 export const dim = (text: string) => styleText('dim', text);

--- a/tests/cli/cli.spec.ts
+++ b/tests/cli/cli.spec.ts
@@ -99,4 +99,13 @@ describe.concurrent('CLI Integration Tests', () => {
 
 		expect(extracted).toMatchSnapshot();
 	});
+
+	test('logs a warning when --null-as-default-value is used with pot format', async ({ expect }) => {
+		const OUTPUT_FILE = createUniqueFileName('strings.po');
+		const { stdout } = await execAsync(
+			`node ${CLI_PATH} --input ${FIXTURES_PATH} --output ${OUTPUT_FILE} --format=pot --null-as-default-value`,
+		);
+
+		expect(stdout).toContain('WARNING: POT format does not support --null-as-default-value.');
+	});
 });

--- a/tests/utils/cli-color.spec.ts
+++ b/tests/utils/cli-color.spec.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, it, expect } from 'vitest';
 
-import { cyan, green, bold, dim, red } from './../../src/utils/cli-color.js';
+import { cyan, green, bold, dim, red, yellow } from './../../src/utils/cli-color.js';
 
 process.env.FORCE_COLOR = '1';
 
@@ -45,5 +45,11 @@ describe('cli-color', () => {
 		const result = red(sampleText);
 		const ANSIRed = `\u001b[31m${sampleText}\u001b[39m`;
 		expect(result).toBe(ANSIRed);
+	});
+
+	it('should wrap text in yellow', () => {
+		const result = yellow(sampleText);
+		const ANSIYellow = `\u001b[33m${sampleText}\u001b[39m`;
+		expect(result).toBe(ANSIYellow);
 	});
 });


### PR DESCRIPTION
`null` values are not supported by pot format and the compiler converts them to empty strings. This change adds a warning message for this behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/ngx-translate-extract/pr/148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783197078&installation_id=128408429&pr_number=148&repository=vendurehq%2Fngx-translate-extract&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fngx-translate-extract%2Fpull%2F148&signature=d334099e1b760c353e7261115732c452b078c6fcbd5d0b78e6d8798687de6209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->