### PR TITLE
refactor: replace manual object iteration with objectMap/objectSome utilities

### DIFF
--- a/src/compilers/json.compiler.ts
+++ b/src/compilers/json.compiler.ts
@@ -1,8 +1,8 @@
 import { flatten } from 'flat';
 
-import { TranslationCollection, TranslationInterface, TranslationType } from '../utils/translation.collection.js';
-import { stripBOM } from '../utils/utils.js';
-import { CompilerInterface, CompilerOptions } from './compiler.interface.js';
+import { TranslationCollection } from '../utils/translation.collection.js';
+import { objectMap, objectSome, stripBOM } from '../utils/utils.js';
+import { type CompilerInterface, type CompilerOptions } from './compiler.interface.js';
 
 export class JsonCompiler implements CompilerInterface {
 	public indentation: string = '\t';
@@ -28,8 +28,7 @@ export class JsonCompiler implements CompilerInterface {
 		if (this.isNamespacedJsonFormat(values)) {
 			values = flatten(values);
 		}
-		const newValues: TranslationType = {};
-		Object.entries(values).forEach(([key, value]) => (newValues[key] = <TranslationInterface>{ value: value, sourceFiles: [] }));
+		const newValues = objectMap(values, (value) => ({ value: value === null ? null : `${value}`, sourceFiles: [] }));
 		return new TranslationCollection(newValues);
 	}
 
@@ -38,10 +37,10 @@ export class JsonCompiler implements CompilerInterface {
 			return false;
 		}
 
-		return Object.keys(values).some((key) => typeof values[key] === 'object');
+		return objectSome(values, (value) => isObject(value));
 	}
 }
 
 function isObject(value: unknown): value is Record<string, unknown> {
-	return typeof value === 'object' && value !== null;
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/src/compilers/namespaced-json.compiler.ts
+++ b/src/compilers/namespaced-json.compiler.ts
@@ -1,8 +1,8 @@
 import { flatten, unflatten } from 'flat';
 
-import { TranslationCollection, TranslationInterface, TranslationType } from '../utils/translation.collection.js';
-import { stripBOM } from '../utils/utils.js';
-import { CompilerInterface, CompilerOptions } from './compiler.interface.js';
+import { TranslationCollection } from '../utils/translation.collection.js';
+import { objectMap, stripBOM } from '../utils/utils.js';
+import { type CompilerInterface, type CompilerOptions } from './compiler.interface.js';
 
 export class NamespacedJsonCompiler implements CompilerInterface {
 	public indentation: string = '\t';
@@ -26,10 +26,7 @@ export class NamespacedJsonCompiler implements CompilerInterface {
 
 	public parse(contents: string): TranslationCollection {
 		const values: Record<string, string> = flatten(JSON.parse(stripBOM(contents)));
-		const newValues: TranslationType = {};
-		Object.entries(values).forEach(
-			([key, value]: [string, string]) => (newValues[key] = <TranslationInterface>{ value: value, sourceFiles: [] }),
-		);
+		const newValues = objectMap(values, (value) => ({ value: value === null ? null : `${value}`, sourceFiles: [] }));
 		return new TranslationCollection(newValues);
 	}
 }

--- a/src/utils/translation.collection.ts
+++ b/src/utils/translation.collection.ts
@@ -1,4 +1,5 @@
 import { normalizeFilePath } from './fs-helpers.js';
+import { objectMap } from './utils.js';
 
 export interface TranslationType {
 	[key: string]: TranslationInterface;
@@ -105,9 +106,7 @@ export class TranslationCollection {
 	}
 
 	public toKeyValueObject(): { [key: string]: string | null } {
-		const jsonTranslations: { [key: string]: string | null } = {};
-		Object.entries(this.values).map(([key, value]: [string, TranslationInterface]) => (jsonTranslations[key] = value.value));
-		return jsonTranslations;
+		return objectMap(this.values, (value) => value.value);
 	}
 
 	public stripKeyPrefix(prefix: string): TranslationCollection {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,35 @@
+type CallbackFn<T, U = void> = (value: T, key: string, obj: Record<string, T>) => U;
+
 export function stripBOM(contents: string): string {
 	return contents.trim();
+}
+
+/**
+ * Maps an object's own enumerable properties to a new object (like Array.map()).
+ */
+export function objectMap<T, U>(obj: Record<string, T>, callback: CallbackFn<T, U>): Record<string, U> {
+	const keys = Object.keys(obj);
+	const len = keys.length;
+	const result: Record<string, U> = Object.create(null);
+	for (let i = 0; i < len; i++) {
+		const key = keys[i];
+		result[key] = callback(obj[key], key, obj);
+	}
+	return result;
+}
+
+/**
+ * Tests whether at least one element in the object passes the test.
+ * Short-circuits upon finding a truthy value (like Array.some()).
+ */
+export function objectSome<T>(obj: Record<string, T>, predicate: CallbackFn<T, boolean>): boolean {
+	const keys = Object.keys(obj);
+	const len = keys.length;
+	for (let i = 0; i < len; i++) {
+		const key = keys[i];
+		if (predicate(obj[key], key, obj)) {
+			return true;
+		}
+	}
+	return false;
 }

--- a/tests/compilers/json.compiler.spec.ts
+++ b/tests/compilers/json.compiler.spec.ts
@@ -10,17 +10,181 @@ describe('JsonCompiler', () => {
 		compiler = new JsonCompiler();
 	});
 
-	it('should parse to a translation interface', () => {
-		const contents = `
-			{
-				"key": "value",
-				"secondKey": ""
-			}
-		`;
-		const collection: TranslationCollection = compiler.parse(contents);
-		expect(collection.values).to.deep.equal({
-			key: { value: 'value', sourceFiles: [] },
-			secondKey: { value: '', sourceFiles: [] },
+	describe('parse()', () => {
+		it('should parse to a translation interface', () => {
+			const contents = `
+				{
+					"key": "value",
+					"secondKey": ""
+				}
+			`;
+			const collection: TranslationCollection = compiler.parse(contents);
+			expect(collection.values).to.deep.equal({
+				key: { value: 'value', sourceFiles: [] },
+				secondKey: { value: '', sourceFiles: [] },
+			});
+		});
+
+		it('should strip BOM and surrounding whitespace', () => {
+			const contents = '\uFEFF  {"key": "value"}  \n';
+			const collection = compiler.parse(contents);
+			expect(collection.values).toEqual({
+				key: { value: 'value', sourceFiles: [] },
+			});
+		});
+
+		it('should flatten namespaced JSON into dotted keys', () => {
+			const contents = `
+				{
+					"namespace": {
+						"key": "value",
+						"nested": {
+							"deep": "deepValue"
+						}
+					},
+					"flatKey": "flatValue"
+				}
+			`;
+			const collection = compiler.parse(contents);
+			expect(collection.values).toEqual({
+				'namespace.key': { value: 'value', sourceFiles: [] },
+				'namespace.nested.deep': { value: 'deepValue', sourceFiles: [] },
+				flatKey: { value: 'flatValue', sourceFiles: [] },
+			});
+		});
+
+		it('should preserve null values as null instead of the string "null"', () => {
+			const contents = `
+				{
+					"key": null,
+					"otherKey": "value"
+				}
+			`;
+			const collection = compiler.parse(contents);
+			expect(collection.values).toEqual({
+				key: { value: null, sourceFiles: [] },
+				otherKey: { value: 'value', sourceFiles: [] },
+			});
+		});
+
+		it('should not treat a flat JSON containing null values as namespaced', () => {
+			const contents = `
+				{
+					"key": null,
+					"secondKey": "value"
+				}
+			`;
+			const collection = compiler.parse(contents);
+			// null must not trigger the flatten() code path or mangle keys
+			expect(collection.keys()).toEqual(['key', 'secondKey']);
+		});
+
+		it('should coerce primitive non-string values to strings', () => {
+			const contents = `
+				{
+					"count": 42,
+					"enabled": true
+				}
+			`;
+			const collection = compiler.parse(contents);
+			expect(collection.values).toEqual({
+				count: { value: '42', sourceFiles: [] },
+				enabled: { value: 'true', sourceFiles: [] },
+			});
+		});
+
+		it('should not treat array values as namespaced JSON', () => {
+			const contents = `
+				{
+					"list": ["a", "b"],
+					"key": "value"
+				}
+			`;
+			const collection = compiler.parse(contents);
+			// arrays must not trigger flatten(): no "list.0"/"list.1" keys
+			expect(collection.keys()).toEqual(['list', 'key']);
+		});
+
+		it('should flatten when at least one value is a nested object', () => {
+			const contents = `
+				{
+					"flat": "value",
+					"nested": { "key": "value" }
+				}
+			`;
+			const collection = compiler.parse(contents);
+			expect(collection.keys()).toEqual(['flat', 'nested.key']);
+		});
+
+		it('should parse an empty object to an empty collection', () => {
+			const collection = compiler.parse('{}');
+			expect(collection.isEmpty()).toEqual(true);
+		});
+
+		it('should throw on invalid JSON', () => {
+			expect(() => compiler.parse('{ not valid }')).toThrow(SyntaxError);
+		});
+	});
+
+	describe('compile()', () => {
+		it('should compile a collection to flat JSON with tab indentation by default', () => {
+			const collection = new TranslationCollection({
+				key: { value: 'value', sourceFiles: [] },
+			});
+			const result = compiler.compile(collection);
+			expect(result).to.equal('{\n\t"key": "value"\n}');
+		});
+
+		it('should keep dotted keys flat instead of nesting them', () => {
+			const collection = new TranslationCollection({
+				'namespace.key': { value: 'value', sourceFiles: [] },
+			});
+			const result = compiler.compile(collection);
+			expect(JSON.parse(result)).toEqual({ 'namespace.key': 'value' });
+		});
+
+		it('should serialize null values as JSON null', () => {
+			const collection = new TranslationCollection({
+				key: { value: null, sourceFiles: [] },
+			});
+			const result = compiler.compile(collection);
+			expect(JSON.parse(result)).toEqual({ key: null });
+		});
+
+		it('should respect a custom indentation option', () => {
+			compiler = new JsonCompiler({ indentation: '  ' });
+			const collection = new TranslationCollection({
+				key: { value: 'value', sourceFiles: [] },
+			});
+			expect(compiler.compile(collection)).to.equal('{\n  "key": "value"\n}');
+		});
+
+		it('should append a trailing newline when configured', () => {
+			compiler = new JsonCompiler({ trailingNewline: true });
+			const collection = new TranslationCollection({
+				key: { value: 'value', sourceFiles: [] },
+			});
+			expect(compiler.compile(collection).endsWith('}\n')).to.equal(true);
+		});
+
+		it('should not append a trailing newline by default', () => {
+			const collection = new TranslationCollection({
+				key: { value: 'value', sourceFiles: [] },
+			});
+			expect(compiler.compile(collection).endsWith('}')).to.equal(true);
+		});
+	});
+
+	describe('round-trip', () => {
+		it('should survive a compile → parse round-trip without data loss', () => {
+			const collection = new TranslationCollection({
+				key: { value: 'value', sourceFiles: [] },
+				'name.spaced': { value: 'other', sourceFiles: [] },
+				empty: { value: '', sourceFiles: [] },
+				missing: { value: null, sourceFiles: [] },
+			});
+			const reparsed = compiler.parse(compiler.compile(collection));
+			expect(reparsed.values).toEqual(collection.values);
 		});
 	});
 });


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/ngx-translate-extract/pr/155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785004472&installation_id=128408429&pr_number=155&repository=vendurehq%2Fngx-translate-extract&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fngx-translate-extract%2Fpull%2F155&signature=14fbe441397d8c489c6cf4fd79eaf29e83da92ca06f5a6fcfeaa00f1cb44c869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->