### PR TITLE
perf(parser): optimize parsing and extraction speed across all parsers

### DIFF
--- a/src/cli/tasks/extract.task.ts
+++ b/src/cli/tasks/extract.task.ts
@@ -185,7 +185,7 @@ export class ExtractTask implements TaskInterface {
 		// Ensure that the pattern consistently uses forward slashes ("/")
 		// for cross-platform compatibility, as Glob patterns should always use "/"
 		const sanitizedPattern = pattern.split(path.sep).join(path.posix.sep);
-		return globSync(sanitizedPattern).filter((filePath) => fs.statSync(filePath).isFile());
+		return globSync(sanitizedPattern, { nodir: true });
 	}
 
 	protected out(...args: unknown[]): void {

--- a/src/parsers/directive.parser.ts
+++ b/src/parsers/directive.parser.ts
@@ -24,7 +24,9 @@ import {
 } from '@angular/compiler';
 
 import { getAST, getNodesFromSwitchBlockTmpl } from '../utils/ast-helpers.js';
-import { TranslationCollection } from '../utils/translation.collection.js';
+import { normalizeFilePath } from '../utils/fs-helpers.js';
+import { TranslationCollection, type TranslationType } from '../utils/translation.collection.js';
+import { toTranslationType } from '../utils/utils.js';
 import { ParserInterface } from './parser.interface.js';
 
 interface BlockNode {
@@ -41,11 +43,12 @@ type ElementLike = Element | Template;
 
 export class DirectiveParser implements ParserInterface {
 	public extract(source: string, filePath: string): TranslationCollection {
-		let collection: TranslationCollection = new TranslationCollection();
+		const extracted: TranslationType = Object.create(null);
+		const filePathNormalized = normalizeFilePath(filePath);
 		const parsedTemplates = getAST(source, filePath).parsedTemplates;
 
 		if (parsedTemplates.length === 0) {
-			return collection;
+			return new TranslationCollection();
 		}
 
 		const nodes: TmplAstNode[] = parsedTemplates.map((parsedTpl) => parsedTpl.nodes).flat();
@@ -54,7 +57,7 @@ export class DirectiveParser implements ParserInterface {
 		elements.forEach((element) => {
 			const attribute = this.getAttribute(element, TRANSLATE_ATTR_NAMES);
 			if (attribute?.value) {
-				collection = collection.add(attribute.value, '', filePath);
+				extracted[attribute.value] = toTranslationType('', filePathNormalized);
 				return;
 			}
 
@@ -64,17 +67,17 @@ export class DirectiveParser implements ParserInterface {
 					if (!literalPrimitive.value) {
 						return;
 					}
-					collection = collection.add(literalPrimitive.value.toString(), '', filePath);
+					extracted[literalPrimitive.value.toString()] = toTranslationType('', filePathNormalized);
 				});
 				return;
 			}
 
 			const textNodes = this.getTextNodes(element);
 			textNodes.forEach((textNode) => {
-				collection = collection.add(textNode.value.trim(), '', filePath);
+				extracted[textNode.value.trim()] = toTranslationType('', filePathNormalized);
 			});
 		});
-		return collection;
+		return new TranslationCollection(extracted);
 	}
 
 	/**
@@ -82,18 +85,18 @@ export class DirectiveParser implements ParserInterface {
 	 * @param nodes
 	 */
 	protected getElementsWithTranslateAttribute(nodes: Node[]): ElementLike[] {
-		let elements: ElementLike[] = [];
+		const elements: ElementLike[] = [];
 
 		nodes.filter(this.isElementLike).forEach((element) => {
 			if (this.hasAttributes(element, TRANSLATE_ATTR_NAMES)) {
-				elements = [...elements, element];
+				elements.push(element);
 			}
 			if (this.hasBoundAttribute(element, TRANSLATE_ATTR_NAMES)) {
-				elements = [...elements, element];
+				elements.push(element);
 			}
 			const childElements = this.getElementsWithTranslateAttribute(element.children);
 			if (childElements.length) {
-				elements = [...elements, ...childElements];
+				elements.push(...childElements);
 			}
 		});
 
@@ -204,9 +207,9 @@ export class DirectiveParser implements ParserInterface {
 			visit = [exp.expression];
 		}
 
-		let results: LiteralPrimitive[] = [];
+		const results: LiteralPrimitive[] = [];
 		visit.forEach((child) => {
-			results = [...results, ...this.getLiteralPrimitives(child)];
+			results.push(...this.getLiteralPrimitives(child));
 		});
 		return results;
 	}

--- a/src/parsers/function.parser.ts
+++ b/src/parsers/function.parser.ts
@@ -1,7 +1,9 @@
 import pkg from 'typescript';
 
 import { getStringsFromExpression, findSimpleCallExpressions, getAST } from '../utils/ast-helpers.js';
-import { TranslationCollection } from '../utils/translation.collection.js';
+import { normalizeFilePath } from '../utils/fs-helpers.js';
+import { TranslationCollection, type TranslationType } from '../utils/translation.collection.js';
+import { toTranslationType } from '../utils/utils.js';
 import { ParserInterface } from './parser.interface.js';
 const { isIdentifier } = pkg;
 
@@ -9,11 +11,12 @@ export class FunctionParser implements ParserInterface {
 	constructor(private fnName: string) {}
 
 	public extract(source: string, filePath: string): TranslationCollection {
-		let collection: TranslationCollection = new TranslationCollection();
+		const extracted: TranslationType = Object.create(null);
+		const filePathNormalized = normalizeFilePath(filePath);
 		const sourceFile = getAST(source, filePath).parsedFile;
 
 		if (!sourceFile) {
-			return collection;
+			return new TranslationCollection();
 		}
 
 		const callExpressions = findSimpleCallExpressions(sourceFile, this.fnName);
@@ -26,9 +29,10 @@ export class FunctionParser implements ParserInterface {
 			if (!firstArg) {
 				return;
 			}
-			const strings = getStringsFromExpression(firstArg);
-			collection = collection.addKeys(strings, filePath);
+			getStringsFromExpression(firstArg).forEach((key) => {
+				extracted[key] = toTranslationType('', filePathNormalized);
+			});
 		});
-		return collection;
+		return new TranslationCollection(extracted);
 	}
 }

--- a/src/parsers/marker.parser.ts
+++ b/src/parsers/marker.parser.ts
@@ -1,7 +1,9 @@
 import { SourceFile } from 'typescript';
 
 import { getNamedImportAlias, findFunctionCallExpressions, getStringsFromExpression, getAST } from '../utils/ast-helpers.js';
-import { TranslationCollection } from '../utils/translation.collection.js';
+import { normalizeFilePath } from '../utils/fs-helpers.js';
+import { TranslationCollection, type TranslationType } from '../utils/translation.collection.js';
+import { toTranslationType } from '../utils/utils.js';
 import { ParserInterface } from './parser.interface.js';
 
 const MARKER_MODULE_NAME = new RegExp('ngx-translate-extract-marker');
@@ -11,16 +13,17 @@ const NGX_TRANSLATE_MARKER_IMPORT_NAME = '_';
 
 export class MarkerParser implements ParserInterface {
 	public extract(source: string, filePath: string): TranslationCollection {
-		let collection = new TranslationCollection();
+		const extracted: TranslationType = Object.create(null);
+		const filePathNormalized = normalizeFilePath(filePath);
 		const sourceFile = getAST(source, filePath).parsedFile;
 
 		if (!sourceFile) {
-			return collection;
+			return new TranslationCollection();
 		}
 
 		const markerImportName = this.getMarkerImportNameFromSource(sourceFile);
 		if (!markerImportName) {
-			return collection;
+			return new TranslationCollection();
 		}
 
 		const callExpressions = findFunctionCallExpressions(sourceFile, markerImportName);
@@ -29,10 +32,11 @@ export class MarkerParser implements ParserInterface {
 			if (!firstArg) {
 				return;
 			}
-			const strings = getStringsFromExpression(firstArg);
-			collection = collection.addKeys(strings, filePath);
+			getStringsFromExpression(firstArg).forEach((key) => {
+				extracted[key] = toTranslationType('', filePathNormalized);
+			});
 		});
-		return collection;
+		return new TranslationCollection(extracted);
 	}
 
 	private getMarkerImportNameFromSource(sourceFile: SourceFile): string {

--- a/src/parsers/pipe.parser.ts
+++ b/src/parsers/pipe.parser.ts
@@ -21,7 +21,9 @@ import {
 } from '@angular/compiler';
 
 import { getAST, getNodesFromSwitchBlockTmpl } from '../utils/ast-helpers.js';
-import { TranslationCollection } from '../utils/translation.collection.js';
+import { normalizeFilePath } from '../utils/fs-helpers.js';
+import { TranslationCollection, type TranslationType } from '../utils/translation.collection.js';
+import { toTranslationType } from '../utils/utils.js';
 import { ParserInterface } from './parser.interface.js';
 
 export const TRANSLATE_PIPE_NAMES = ['translate', 'marker'];
@@ -81,11 +83,12 @@ function traverseAstNode<T>(
 
 export class PipeParser implements ParserInterface {
 	public extract(source: string, filePath: string): TranslationCollection {
+		const filePathNormalized = normalizeFilePath(filePath);
 		const parsedTemplates = getAST(source, filePath).parsedTemplates;
 		if (parsedTemplates.length === 0) {
 			return new TranslationCollection();
 		}
-		let collection: TranslationCollection = new TranslationCollection();
+		const extracted: TranslationType = Object.create(null);
 		const nodes: TmplAstNode[] = parsedTemplates.map((parsedTpl) => parsedTpl.nodes).flat();
 		const pipes = traverseAstNodes(nodes, (node) => this.findPipesInNode(node));
 
@@ -94,10 +97,10 @@ export class PipeParser implements ParserInterface {
 				if (key === '') {
 					return;
 				}
-				collection = collection.add(key, '', filePath);
+				extracted[key] = toTranslationType('', filePathNormalized);
 			});
 		});
-		return collection;
+		return new TranslationCollection(extracted);
 	}
 
 	protected findPipesInNode(node: TmplAstNode): BindingPipe[] {
@@ -109,7 +112,7 @@ export class PipeParser implements ParserInterface {
 
 		if ('attributes' in node && Array.isArray(node.attributes)) {
 			const translatableAttributes = node.attributes.filter((attr) => TRANSLATE_PIPE_NAMES.includes(attr.name));
-			ret.push(...ret, ...translatableAttributes);
+			ret.push(...translatableAttributes);
 		}
 
 		if ('inputs' in node && Array.isArray(node.inputs)) {

--- a/src/parsers/service.parser.ts
+++ b/src/parsers/service.parser.ts
@@ -19,7 +19,9 @@ import {
 	getAST,
 	getNamedImport,
 } from '../utils/ast-helpers.js';
-import { TranslationCollection } from '../utils/translation.collection.js';
+import { normalizeFilePath } from '../utils/fs-helpers.js';
+import { TranslationCollection, type TranslationType } from '../utils/translation.collection.js';
+import { toTranslationType } from '../utils/utils.js';
 import { ParserInterface } from './parser.interface.js';
 
 const TRANSLATE_SERVICE_TYPE_REFERENCE = 'TranslateService';
@@ -29,18 +31,19 @@ export class ServiceParser implements ParserInterface {
 	private static propertyMap = new Map<string, string[]>();
 
 	public extract(source: string, filePath: string): TranslationCollection {
-		let collection = new TranslationCollection();
+		const extracted: TranslationType = Object.create(null);
+		const filePathNormalized = normalizeFilePath(filePath);
 		const sourceFile = getAST(source, filePath).parsedFile;
 
 		if (!sourceFile) {
-			return collection;
+			return new TranslationCollection();
 		}
 
 		const classDeclarations = findClassDeclarations(sourceFile);
 		const functionDeclarations = findFunctionExpressions(sourceFile);
 
 		if (classDeclarations.length === 0 && functionDeclarations.length === 0) {
-			return collection;
+			return new TranslationCollection();
 		}
 
 		const translateServiceCallExpressions: CallExpression[] = [];
@@ -74,11 +77,12 @@ export class ServiceParser implements ParserInterface {
 				if (!firstArg) {
 					return;
 				}
-				const strings = getStringsFromExpression(firstArg);
-				collection = collection.addKeys(strings, filePath);
+				getStringsFromExpression(firstArg).forEach((key) => {
+					extracted[key] = toTranslationType('', filePathNormalized);
+				});
 			});
 
-		return collection;
+		return new TranslationCollection(extracted);
 	}
 
 	protected findConstructorParamCallExpressions(classDeclaration: ClassDeclaration): CallExpression[] {

--- a/src/parsers/translate-function.parser.ts
+++ b/src/parsers/translate-function.parser.ts
@@ -1,19 +1,22 @@
 import { getNamedImportAlias, findFunctionCallExpressions, getStringsFromExpression, getAST } from '../utils/ast-helpers.js';
-import { TranslationCollection } from '../utils/translation.collection.js';
+import { normalizeFilePath } from '../utils/fs-helpers.js';
+import { TranslationCollection, type TranslationType } from '../utils/translation.collection.js';
+import { toTranslationType } from '../utils/utils.js';
 import { ParserInterface } from './parser.interface.js';
 
 export class TranslateFunctionParser implements ParserInterface {
 	public extract(source: string, filePath: string): TranslationCollection {
-		let collection = new TranslationCollection();
+		const extracted: TranslationType = Object.create(null);
+		const filePathNormalized = normalizeFilePath(filePath);
 		const sourceFile = getAST(source, filePath).parsedFile;
 
 		if (!sourceFile) {
-			return collection;
+			return new TranslationCollection();
 		}
 
 		const translateFnImportName = getNamedImportAlias(sourceFile, 'translate', '@ngx-translate/core');
 		if (!translateFnImportName) {
-			return collection;
+			return new TranslationCollection();
 		}
 
 		const callExpressions = findFunctionCallExpressions(sourceFile, translateFnImportName);
@@ -23,10 +26,11 @@ export class TranslateFunctionParser implements ParserInterface {
 			if (!firstArg) {
 				return;
 			}
-			const strings = getStringsFromExpression(firstArg);
-			collection = collection.addKeys(strings, filePath);
+			getStringsFromExpression(firstArg).forEach((key) => {
+				extracted[key] = toTranslationType('', filePathNormalized);
+			});
 		});
 
-		return collection;
+		return new TranslationCollection(extracted);
 	}
 }

--- a/src/utils/translation.collection.ts
+++ b/src/utils/translation.collection.ts
@@ -24,14 +24,12 @@ export class TranslationCollection {
 	}
 
 	public addKeys(keys: string[], sourceFile: string): TranslationCollection {
-		const values = keys.reduce(
-			(results, key) => ({
-				...results,
-				[key]: <TranslationInterface>{ value: '', sourceFiles: [normalizeFilePath(sourceFile)] },
-			}),
-			{} as TranslationType,
-		);
-		return new TranslationCollection({ ...this.values, ...values });
+		const normalizedSourceFile = normalizeFilePath(sourceFile);
+		const values: TranslationType = { ...this.values };
+		for (const key of keys) {
+			values[key] = { value: '', sourceFiles: [normalizedSourceFile] };
+		}
+		return new TranslationCollection(values);
 	}
 
 	public remove(key: string): TranslationCollection {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,5 @@
+import { type TranslationInterface } from './translation.collection.js';
+
 type CallbackFn<T, U = void> = (value: T, key: string, obj: Record<string, T>) => U;
 
 export function stripBOM(contents: string): string {
@@ -32,4 +34,8 @@ export function objectSome<T>(obj: Record<string, T>, predicate: CallbackFn<T, b
 		}
 	}
 	return false;
+}
+
+export function toTranslationType(value: string, filePath: string): TranslationInterface {
+	return { value: value, sourceFiles: [filePath] };
 }


### PR DESCRIPTION
Benchmarked with `vitest bench` (1000 keys per parser), compared against the pre-optimization baseline:

| Parser      | Before    | After    | Speedup |
|-------------|-----------|----------|---------|
| Directive   | 70.89 ms  | 0.16 ms  | ~446x   |
| Pipe        | 69.71 ms  | 0.47 ms  | ~148x   |
| Function    | 78.98 ms  | 2.85 ms  | ~28x    |
| Marker      | 77.68 ms  | 6.89 ms  | ~11x    |
| TranslateFn | 82.25 ms  | 6.99 ms  | ~11x    |
| Service     | 105.70 ms | 31.26 ms | ~3.4x   |

(relative margin of error <= 1.7% across all runs)

The quadratic accumulation affected every parser (baselines all ~70–105 ms for 1000 keys). Directive and Pipe have the largest gains as they also had O(n^2) array rebuilding in AST traversal. Service has the smallest gain because its very heavy with AST traversal to resolve classes,  parent classes and inject resolution, but still not bad increase.

# Benchmark Implementations

These are the benchmark suites used to verify the performance improvements:

## DirectiveParser
```typescript
import { bench, describe } from 'vitest';
import { DirectiveParser } from '../../src/parsers/directive.parser.js';

const KEY_COUNT = 1000;
function buildTemplate(count: number): string {
    return Array.from({ length: count }, (_, i) => `<p translate>directive.key.${i}</p>`).join('\n');
}

describe('DirectiveParser', () => {
    const source = buildTemplate(KEY_COUNT);
    const parser = new DirectiveParser();
    bench(`extract ${KEY_COUNT} keys`, () => {
        parser.extract(source, 'template.html');
    });
});
```

## FunctionParser
```typescript
import { bench, describe } from 'vitest';

import { FunctionParser } from '../../src/parsers/function.parser.js';

const KEY_COUNT = 1000;
const FN_NAME = 'translate';

function buildSource(count: number): string {
	const calls = Array.from({ length: count }, (_, i) => `${FN_NAME}('function.key.${i}');`).join('\n');
	return calls;
}

describe('FunctionParser', () => {
	const source = buildSource(KEY_COUNT);
	const parser = new FunctionParser(FN_NAME);

	bench(`extract ${KEY_COUNT} keys`, () => {
		parser.extract(source, 'source.ts');
	});
});
```


## MarkerParser
```typescript
import { bench, describe } from 'vitest';

import { MarkerParser } from '../../src/parsers/marker.parser.js';

const KEY_COUNT = 1000;

function buildSource(count: number): string {
	const calls = Array.from({ length: count }, (_, i) => `_('marker.key.${i}');`).join('\n');
	return `
import { _ } from '@ngx-translate/core';

${calls}
`;
}

describe('MarkerParser', () => {
	const source = buildSource(KEY_COUNT);
	const parser = new MarkerParser();

	bench(`extract ${KEY_COUNT} keys`, () => {
		parser.extract(source, 'source.ts');
	});
});
```

## PipeParser
```typescript
import { bench, describe } from 'vitest';

import { PipeParser } from '../../src/parsers/pipe.parser.js';

const KEY_COUNT = 1000;

function buildTemplate(count: number): string {
	return Array.from({ length: count }, (_, i) => `<p>{{ 'pipe.key.${i}' | translate }}</p>`).join('\n');
}

describe('PipeParser', () => {
	const source = buildTemplate(KEY_COUNT);
	const parser = new PipeParser();

	bench(`extract ${KEY_COUNT} keys`, () => {
		parser.extract(source, 'template.html');
	});
});
```

## ServiceParser
```typescript
import { bench, describe } from 'vitest';

import { ServiceParser } from '../../src/parsers/service.parser.js';

const KEY_COUNT = 1000;

function buildSource(count: number): string {
	const calls = Array.from({ length: count }, (_, i) => `\t\tthis.translateService.get('service.key.${i}');`).join('\n');
	return `
import { TranslateService } from '@ngx-translate/core';

export class MyComponent {
	constructor(private translateService: TranslateService) {}

	ngOnInit(): void {
		${calls}
	}
}
`;
}

describe('ServiceParser', () => {
	const source = buildSource(KEY_COUNT);
	const parser = new ServiceParser();

	bench(`extract ${KEY_COUNT} keys`, () => {
		parser.extract(source, 'component.ts');
	});
});
```

## TranslateFnParser
```typescript
import { bench, describe } from 'vitest';

import { TranslateFunctionParser } from '../../src/parsers/translate-function.parser.js';

const KEY_COUNT = 1000;

function buildSource(count: number): string {
	const calls = Array.from({ length: count }, (_, i) => `readonly translatable${i} = translate('translatefn.key.${i}');`).join('\n');
	return `
import { translate } from '@ngx-translate/core';

@Component({ template: '' })
export class App {
	${calls}
}
`;
}

describe('TranslateFnParser', () => {
	const source = buildSource(KEY_COUNT);
	const parser = new TranslateFunctionParser();

	bench(`extract ${KEY_COUNT} keys`, () => {
		parser.extract(source, 'source.ts');
	});
});
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/ngx-translate-extract/pr/156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785702047&installation_id=128408429&pr_number=156&repository=vendurehq%2Fngx-translate-extract&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fngx-translate-extract%2Fpull%2F156&signature=aec99ac21f1c1b706ef223fea675e5c0651c6b89cac9d14c80605ed7734703ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->