### PR TITLE
refactor(ast-helpers): optimise AST queries and resolve parsing edge cases

### DIFF
--- a/src/utils/ast-helpers.ts
+++ b/src/utils/ast-helpers.ts
@@ -7,6 +7,7 @@ import pkg, {
 	type ClassDeclaration,
 	type ConstructorDeclaration,
 	type Expression,
+	type HeritageClause,
 	type Identifier,
 	type Node,
 	type PropertyAccessExpression,
@@ -40,7 +41,12 @@ const {
 	isConditionalExpression,
 	isPropertyAccessExpression,
 	isStringLiteralLike,
+	isTypeReferenceNode,
+	isGetAccessorDeclaration,
+	isVariableDeclaration,
+	isParenthesizedExpression,
 	SyntaxKind,
+	forEachChild,
 } = pkg;
 
 const ANGULAR_TEMPLATE_KIND = ScriptKind.Unknown; // Unknown for ts
@@ -56,9 +62,29 @@ const SCRIPT_TYPES = new Map([
 ]);
 
 const AST_CACHE = new Map<string, ParsedSource>();
+let TSQUERY_CACHE = new WeakMap<Node, Map<string, unknown[]>>();
+
+/**
+ * Cache wrapper for tsquery to prevent redundant full-AST traversals
+ * on the same node for the same query.
+ */
+function runQuery<T extends Node = Node>(node: Node, query: string): T[] {
+	let nodeCache = TSQUERY_CACHE.get(node);
+	if (!nodeCache) {
+		nodeCache = new Map();
+		TSQUERY_CACHE.set(node, nodeCache);
+	}
+	let result = nodeCache.get(query);
+	if (!result) {
+		result = tsquery<T>(node, query);
+		nodeCache.set(query, result);
+	}
+	return result as T[];
+}
 
 export function clearAstCache(): void {
 	AST_CACHE.clear();
+	TSQUERY_CACHE = new WeakMap();
 }
 
 export function getAST(source: string, fileName = ''): ParsedSource {
@@ -110,9 +136,19 @@ export function parseSource(source: string, fileName = ''): ParsedSource {
  * Retrieves inline `template` property assignments from Angular `@Component` decorators.
  */
 export function getComponentInlineTemplate(node: Node): PropertyAssignment[] {
-	const query =
-		'Decorator > CallExpression:has(Identifier[name="Component"]) ObjectLiteralExpression > PropertyAssignment:has(Identifier[name="template"])';
-	return tsquery<PropertyAssignment>(node, query);
+	const query = 'Decorator PropertyAssignment';
+	const assignments = runQuery<PropertyAssignment>(node, query);
+
+	return assignments.filter((prop) => {
+		if (prop.name.getText() !== 'template') {
+			return false;
+		}
+
+		const objectLiteral = prop.parent;
+		const callExpression = objectLiteral?.parent;
+
+		return isCallExpression(callExpression) && callExpression.expression.getText() === 'Component';
+	});
 }
 
 /**
@@ -122,8 +158,7 @@ export function getNamedImportIdentifiers(node: Node, moduleName: string, import
 	const importStringLiteralValue = importPath instanceof RegExp ? `value=${importPath.toString()}` : `value="${importPath}"`;
 
 	const query = `ImportDeclaration:has(StringLiteral[${importStringLiteralValue}]) ImportSpecifier:has(Identifier[name="${moduleName}"]) > Identifier`;
-
-	return tsquery<Identifier>(node, query);
+	return runQuery<Identifier>(node, query);
 }
 
 /**
@@ -159,27 +194,37 @@ export function getNamedImportAlias(node: Node, importName: string, importPath: 
 }
 
 export function findClassDeclarations(node: Node, name?: string): ClassDeclaration[] {
-	let query = 'ClassDeclaration';
+	const query = 'ClassDeclaration';
+	const classes = runQuery<ClassDeclaration>(node, query);
 	if (name) {
-		query += `:has(Identifier[name="${name}"])`;
+		return classes.filter((c) => c.name && c.name.text === name);
 	}
-	return tsquery<ClassDeclaration>(node, query);
+	return classes;
 }
 
 export function findFunctionExpressions(node: Node) {
-	return tsquery(node, 'VariableDeclaration ArrowFunction, VariableDeclaration FunctionExpression');
+	return runQuery(node, 'VariableDeclaration ArrowFunction, VariableDeclaration FunctionExpression');
 }
 
 export function getSuperClassName(node: Node): string | null {
-	const query = 'ClassDeclaration > HeritageClause Identifier';
-	const [result] = tsquery<Identifier>(node, query);
-	return result?.text ?? null;
+	const query = 'ClassDeclaration > HeritageClause';
+	const clauses = runQuery<HeritageClause>(node, query);
+
+	const extendsClause = clauses.find((c) => c.token === SyntaxKind.ExtendsKeyword);
+	if (!extendsClause) {
+		return null;
+	}
+
+	// 3. Grab the Identifier representing the class name being extended
+	const [identifier] = runQuery<Identifier>(extendsClause, 'Identifier');
+	return identifier?.text ?? null;
 }
 
 export function getImportPath(node: Node, className: string): string | null {
-	const query = `ImportDeclaration:has(Identifier[name="${className}"]) StringLiteral`;
-	const [result] = tsquery<StringLiteral>(node, query);
-	return result?.text ?? null;
+	const query = `ImportDeclaration StringLiteral`;
+	const literals = runQuery<StringLiteral>(node, query);
+	const match = literals.find((l) => hasIdentifierNamed(l.parent, className));
+	return match?.text ?? null;
 }
 
 export function findClassPropertiesByType(node: ClassDeclaration, type: string): string[] {
@@ -193,24 +238,31 @@ export function findClassPropertiesByType(node: ClassDeclaration, type: string):
 
 export function findConstructorDeclaration(node: ClassDeclaration): ConstructorDeclaration | undefined {
 	const query = 'Constructor';
-	const [result] = tsquery<ConstructorDeclaration>(node, query);
+	const [result] = runQuery<ConstructorDeclaration>(node, query);
 	return result;
 }
 
 export function findMethodParameterByType(node: Node, type: string): string | null {
-	const query = `Parameter:has(TypeReference > Identifier[name="${type}"]) > Identifier`;
-	const [result] = tsquery<Identifier>(node, query);
-	if (result) {
-		return result.text;
-	}
-	return null;
+	const query = `Parameter:has(TypeReference) > Identifier`;
+	const params = runQuery<Identifier>(node, query);
+	const match = params.find((p) => hasTypeReferenceNamed(p.parent, type));
+	return match ? match.text : null;
 }
 
 export function findVariableNameByInjectType(node: Node, type: string): string | null {
-	const query = `VariableDeclaration:has(Identifier[name="inject"]):has(CallExpression > Identifier[name="${type}"]) > Identifier`;
-	const [result] = tsquery<Identifier>(node, query);
+	const query = `VariableDeclaration:has(Identifier[name="inject"]) > Identifier`;
+	const allInjects = runQuery<Identifier>(node, query);
+	const match = allInjects.find((identifier) => {
+		const varDecl = identifier.parent;
 
-	return result?.text ?? null;
+		if (!isVariableDeclaration(varDecl)) {
+			return false;
+		}
+
+		// Only search the initializer (the `inject(...)` part), ignoring the variable name
+		return varDecl.initializer && hasIdentifierNamed(varDecl.initializer, type);
+	});
+	return match?.text ?? null;
 }
 
 export function findMethodCallExpressions(node: Node, propName: string, fnName: string | string[]): CallExpression[] {
@@ -218,9 +270,12 @@ export function findMethodCallExpressions(node: Node, propName: string, fnName: 
 
 	const fnNameRegex = functionNames.join('|');
 
-	const query = `CallExpression > PropertyAccessExpression:has(Identifier[name=/^(${fnNameRegex})$/]):has(PropertyAccessExpression:has(Identifier[name="${propName}"]):not(:has(ThisKeyword)))`;
+	const query = `CallExpression > PropertyAccessExpression:has(Identifier[name=/^(${fnNameRegex})$/]):not(:has(ThisKeyword))`;
+	const possibleNodes = runQuery(node, query);
 
-	return unwrapMatchedCallExpressions(tsquery(node, query), functionNames);
+	const matchedNodes = possibleNodes.filter((n) => hasIdentifierNamed(n, propName));
+
+	return unwrapMatchedCallExpressions(matchedNodes, functionNames);
 }
 
 export function findInlineInjectCallExpressions(node: Node, injectType: string, fnName: string | string[]): CallExpression[] {
@@ -228,49 +283,67 @@ export function findInlineInjectCallExpressions(node: Node, injectType: string, 
 
 	const fnNameRegex = functionNames.join('|');
 
-	const query = `CallExpression > PropertyAccessExpression:has(Identifier[name=/^(${fnNameRegex})$/]):has(CallExpression:has(Identifier[name="inject"]):has(Identifier[name="${injectType}"]))`;
+	const query = `CallExpression > PropertyAccessExpression:has(Identifier[name=/^(${fnNameRegex})$/]):has(CallExpression:has(Identifier[name="inject"]))`;
+	const possibleNodes = runQuery(node, query);
 
-	return unwrapMatchedCallExpressions(tsquery(node, query), functionNames);
+	const matchedNodes = possibleNodes.filter((n) => hasIdentifierNamed(n, injectType));
+
+	return unwrapMatchedCallExpressions(matchedNodes, functionNames);
 }
 
 export function findClassPropertiesConstructorParameterByType(node: ClassDeclaration, type: string): string[] {
-	const query = `Constructor Parameter:has(TypeReference > Identifier[name="${type}"]):has(PublicKeyword,ProtectedKeyword,PrivateKeyword,ReadonlyKeyword) > Identifier`;
-	const result = tsquery<Identifier>(node, query);
-	return result.map((n) => n.text);
+	const broadQuery = `Constructor Parameter:has(PublicKeyword,ProtectedKeyword,PrivateKeyword,ReadonlyKeyword) > Identifier`;
+	const params = runQuery<Identifier>(node, broadQuery);
+	return params.filter((p) => hasTypeReferenceNamed(p.parent, type)).map((n) => n.text);
 }
 
 export function findClassPropertiesDeclarationByType(node: ClassDeclaration, type: string): string[] {
-	const query = `PropertyDeclaration:has(TypeReference > Identifier[name="${type}"])`;
-	const result = tsquery<PropertyDeclaration>(node, query);
-	return result.map((n) => n.name.getText());
+	const query = `PropertyDeclaration:has(TypeReference)`;
+	const props = runQuery<PropertyDeclaration>(node, query);
+	return props.filter((p) => p.type && hasTypeReferenceNamed(p.type, type)).map((n) => n.name.getText());
 }
 
 export function findClassPropertiesDeclarationByInject(node: ClassDeclaration, type: string): string[] {
-	const query = `PropertyDeclaration:has(CallExpression > Identifier[name="inject"]):has(CallExpression > Identifier[name="${type}"])`;
-	const result = tsquery<PropertyDeclaration>(node, query);
-	return result.map((n) => n.name.getText());
+	const query = `PropertyDeclaration:has(CallExpression > Identifier[name="inject"])`;
+	const allInjects = runQuery<PropertyDeclaration>(node, query);
+	return (
+		allInjects
+			// Restrict search to the initializer (the `inject(...)` call itself), ignoring the property name
+			.filter((p) => p.initializer && hasIdentifierNamed(p.initializer, type))
+			.map((n) => n.name.getText())
+	);
 }
 
 export function findClassPropertiesGetterByType(node: ClassDeclaration, type: string): string[] {
-	const query = `GetAccessor:has(TypeReference > Identifier[name="${type}"]) > Identifier`;
-	const result = tsquery<Identifier>(node, query);
-	return result.map((n) => n.text);
+	const query = `GetAccessor:has(TypeReference) > Identifier`;
+	const getters = runQuery<Identifier>(node, query);
+	return getters
+		.filter((g) => {
+			const getAccessor = g.parent;
+
+			if (!isGetAccessorDeclaration(getAccessor)) {
+				return false;
+			}
+
+			return getAccessor.type && hasTypeReferenceNamed(getAccessor.type, type);
+		})
+		.map((n) => n.text);
 }
 
 export function findFunctionCallExpressions(node: Node, fnName: string | string[]): CallExpression[] {
 	if (Array.isArray(fnName)) {
 		fnName = fnName.join('|');
 	}
-	const query = `CallExpression:has(Identifier[name="${fnName}"]):not(:has(PropertyAccessExpression))`;
-	return tsquery<CallExpression>(node, query);
+	const query = `CallExpression:has(Identifier[name=/^(${fnName})$/]):not(:has(PropertyAccessExpression))`;
+	return runQuery<CallExpression>(node, query);
 }
 
-export function findSimpleCallExpressions(node: Node, fnName: string) {
+export function findSimpleCallExpressions(node: Node, fnName: string | string[]) {
 	if (Array.isArray(fnName)) {
 		fnName = fnName.join('|');
 	}
-	const query = `CallExpression:has(Identifier[name="${fnName}"])`;
-	return tsquery<CallExpression>(node, query);
+	const query = `CallExpression:has(Identifier[name=/^(${fnName})$/])`;
+	return runQuery<CallExpression>(node, query);
 }
 
 export function findPropertyCallExpressions(node: Node, prop: string, fnName: string | string[]): CallExpression[] {
@@ -279,7 +352,7 @@ export function findPropertyCallExpressions(node: Node, prop: string, fnName: st
 	}
 
 	const query = `CallExpression > PropertyAccessExpression:has(Identifier[name=/^(${fnName})$/]):has(PropertyAccessExpression:has(ThisKeyword))`;
-	const result = tsquery<PropertyAccessExpression>(node, query);
+	const result = runQuery<PropertyAccessExpression>(node, query);
 
 	const nodes: CallExpression[] = [];
 	result.forEach((n) => {
@@ -297,48 +370,55 @@ export function findPropertyCallExpressions(node: Node, prop: string, fnName: st
 }
 
 export function getStringsFromExpression(expression: Expression): string[] {
-	if (isStringLiteralLike(expression) && expression.text.trim() !== '') {
+	return collectStringsFromExpression(expression).filter((s) => s.trim() !== '');
+}
+
+/**
+ * Internal recursive helper that preserves empty and whitespace-only strings
+ * so that binary concatenations (e.g., 'hello' + ' ' + 'world') evaluate correctly.
+ */
+function collectStringsFromExpression(expression: Expression): string[] {
+	if (isParenthesizedExpression(expression)) {
+		return collectStringsFromExpression(expression.expression);
+	}
+
+	if (isStringLiteralLike(expression)) {
 		return [expression.text];
 	}
 
 	if (isArrayLiteralExpression(expression)) {
-		return expression.elements.flatMap(getStringsFromExpression);
+		return expression.elements.flatMap(collectStringsFromExpression);
 	}
 
 	if (isBinaryExpression(expression)) {
-		const [left] = getStringsFromExpression(expression.left);
-		const [right] = getStringsFromExpression(expression.right);
+		const leftStrings = collectStringsFromExpression(expression.left);
+		const rightStrings = collectStringsFromExpression(expression.right);
 
 		if (expression.operatorToken.kind === SyntaxKind.PlusToken) {
-			if (typeof left === 'string' && typeof right === 'string') {
-				return [left + right];
+			// An empty array means a "dynamic side" was encountered.
+			// If either side is dynamic, invalidate the whole string.
+			if (leftStrings.length === 0 || rightStrings.length === 0) {
+				return [];
 			}
+
+			const combinations: string[] = [];
+			for (const l of leftStrings) {
+				for (const r of rightStrings) {
+					combinations.push(l + r);
+				}
+			}
+			return combinations;
 		}
 
 		if (expression.operatorToken.kind === SyntaxKind.BarBarToken) {
-			const result = [];
-			if (typeof left === 'string') {
-				result.push(left);
-			}
-			if (typeof right === 'string') {
-				result.push(right);
-			}
-			return result;
+			return [...leftStrings, ...rightStrings];
 		}
 	}
 
 	if (isConditionalExpression(expression)) {
-		const [whenTrue] = getStringsFromExpression(expression.whenTrue);
-		const [whenFalse] = getStringsFromExpression(expression.whenFalse);
-
-		const result = [];
-		if (typeof whenTrue === 'string') {
-			result.push(whenTrue);
-		}
-		if (typeof whenFalse === 'string') {
-			result.push(whenFalse);
-		}
-		return result;
+		const whenTrue = collectStringsFromExpression(expression.whenTrue);
+		const whenFalse = collectStringsFromExpression(expression.whenFalse);
+		return [...whenTrue, ...whenFalse];
 	}
 	return [];
 }
@@ -381,4 +461,42 @@ export function unwrapMatchedCallExpressions(nodes: Node[], fnNames: string[]): 
 	}
 
 	return results;
+}
+
+/**
+ * AST visitor to search for an Identifier by name.
+ */
+function hasIdentifierNamed(n: Node, name: string): boolean {
+	if (n.kind === SyntaxKind.Identifier && (n as Identifier).text === name) {
+		return true;
+	}
+
+	return !!forEachChild(n, (child) => hasIdentifierNamed(child, name));
+}
+
+/**
+ * AST visitor to search exclusively for a TypeReference
+ * that contains a specific Identifier name.
+ */
+function hasTypeReferenceNamed(n: Node, name: string): boolean {
+	if (n.kind === SyntaxKind.ArrayType) {
+		return false;
+	}
+
+	if (isTypeReferenceNode(n)) {
+		// Match standard identifiers (e.g. TranslateService)
+		if (n.typeName && n.typeName.kind === SyntaxKind.Identifier && n.typeName.text === name) {
+			return true;
+		}
+
+		// Match qualified names (e.g. Core.TranslateService)
+		if (n.typeName && n.typeName.kind === SyntaxKind.QualifiedName && n.typeName.right.text === name) {
+			return true;
+		}
+
+		// Prevents the walker from looking inside <typeArguments>.
+		return false;
+	}
+
+	return !!forEachChild(n, (child) => hasTypeReferenceNamed(child, name));
 }

--- a/tests/utils/ast-helpers.spec.ts
+++ b/tests/utils/ast-helpers.spec.ts
@@ -1,9 +1,30 @@
 import { parseTemplate, TmplAstSwitchBlock } from '@angular/compiler';
-import { ScriptKind, tsquery } from '@phenomnomnominal/tsquery';
-import { LanguageVariant } from 'typescript';
+import { ScriptKind, SyntaxKind, tsquery } from '@phenomnomnominal/tsquery';
+import { LanguageVariant, type ClassDeclaration, isClassDeclaration, type VariableStatement, type Expression } from 'typescript';
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 
-import { getAST, getNamedImport, getNamedImportAlias, getNodesFromSwitchBlockTmpl } from '../../src/utils/ast-helpers.js';
+import {
+	findClassDeclarations,
+	findClassPropertiesConstructorParameterByType,
+	findClassPropertiesDeclarationByInject,
+	findClassPropertiesDeclarationByType,
+	findClassPropertiesGetterByType,
+	findFunctionCallExpressions,
+	findFunctionExpressions,
+	findInlineInjectCallExpressions,
+	findMethodCallExpressions,
+	findMethodParameterByType,
+	findPropertyCallExpressions,
+	findSimpleCallExpressions,
+	findVariableNameByInjectType,
+	getAST,
+	getComponentInlineTemplate,
+	getNamedImport,
+	getNamedImportAlias,
+	getNodesFromSwitchBlockTmpl,
+	getStringsFromExpression,
+	getSuperClassName,
+} from '../../src/utils/ast-helpers.js';
 
 describe('getAST()', () => {
 	const tsqueryAstSpy = vi.spyOn(tsquery, 'ast');
@@ -70,6 +91,71 @@ describe('getAST()', () => {
 
 		expect(tsqueryAstSpy).toHaveBeenCalledWith(source, '', ScriptKind.TS);
 		expect(result.parsedFile.languageVariant).toBe(LanguageVariant.Standard);
+	});
+});
+
+describe('getComponentInlineTemplate()', () => {
+	it('should find the inline template property assignment within a @Component decorator', () => {
+		const code = `
+            @Component({
+                selector: 'app-hello',
+                standalone: true,
+                template: '<div>Hello World</div>',
+                styles: ['div { color: red; }']
+            })
+            export class HelloComponent {}
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const results = getComponentInlineTemplate(node);
+
+		expect(results).toHaveLength(1);
+		// Verify it grabbed the actual PropertyAssignment node ('template: "..."')
+		expect(results[0].name.getText()).toBe('template');
+		expect(results[0].initializer.getText()).toBe("'<div>Hello World</div>'");
+	});
+
+	it('should NOT match when the component uses templateUrl instead of an inline template', () => {
+		const code = `
+            @Component({
+                selector: 'app-hello',
+                templateUrl: './hello.component.html'
+            })
+            export class HelloComponent {}
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const results = getComponentInlineTemplate(node);
+
+		expect(results).toHaveLength(0);
+	});
+
+	it('should ignore template properties in standard objects or other decorators', () => {
+		const code = `
+            // False positive trap 1: A different decorator that happens to have a 'template' property
+            @Directive({
+                selector: '[custom]',
+                template: 'ignored'
+            })
+            export class CustomDirective {}
+
+            // False positive trap 2: A standard variable assignment
+            const config = {
+                template: '<div>Not a component</div>'
+            };
+
+            // False positive trap 3: A nested object inside a Component, but not the root metadata
+            @Component({
+                selector: 'app-wrapper',
+                providers: [{ provide: TEMPLATE_TOKEN, useValue: { template: 'ignored' } }]
+            })
+            export class WrapperComponent {}
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const results = getComponentInlineTemplate(node);
+
+		expect(results).toHaveLength(0);
 	});
 });
 
@@ -169,6 +255,249 @@ describe('getNamedImportAlias()', () => {
 	});
 });
 
+describe('findClassDeclarations()', () => {
+	it('should return all class declarations when no name filter is provided', () => {
+		const code = `
+            class UserService {}
+            class AuthService {}
+            class LoggingService {}
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const results = findClassDeclarations(node);
+
+		const classNames = results.map((c) => c.name?.text);
+		expect(classNames).toEqual(['UserService', 'AuthService', 'LoggingService']);
+	});
+
+	it('should return only the class that matches the specified name', () => {
+		const code = `
+            class UserService {}
+            class AuthService {}
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const results = findClassDeclarations(node, 'AuthService');
+
+		const classNames = results.map((c) => c.name?.text);
+		expect(classNames).toEqual(['AuthService']);
+	});
+
+	it('should handle anonymous/default export classes', () => {
+		const code = `
+            // Anonymous class (common in some routing or module setups)
+            export default class {}
+
+            class NamedService {}
+        `;
+		const node = getAST(code).parsedFile!;
+
+		// Getting all classes should include the anonymous one
+		const allResults = findClassDeclarations(node);
+		expect(allResults).toHaveLength(2);
+
+		// Searching by name should skip the anonymous one without throwing an error
+		const filteredResults = findClassDeclarations(node, 'NamedService');
+		expect(filteredResults).toHaveLength(1);
+		expect(filteredResults[0].name?.text).toBe('NamedService');
+	});
+
+	it('should perform a strict, case-sensitive match and ignore partial matches', () => {
+		const code = `
+            class ConfigService {}
+            class ConfigServiceBase {}
+            class configservice {}
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const results = findClassDeclarations(node, 'ConfigService');
+
+		// Should not match "ConfigServiceBase" (partial match) or "configservice" (wrong casing)
+		expect(results).toHaveLength(1);
+		expect(results[0].name?.text).toBe('ConfigService');
+	});
+});
+
+describe('findFunctionExpressions()', () => {
+	it('should find arrow functions assigned to variables', () => {
+		const code = `
+            const myArrow = (x: number) => x * 2;
+            let helper = () => { console.log('hi'); };
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const results = findFunctionExpressions(node);
+
+		expect(results).toHaveLength(2);
+		expect(results[0].kind).toBe(SyntaxKind.ArrowFunction);
+		expect(results[1].kind).toBe(SyntaxKind.ArrowFunction);
+	});
+
+	it('should find standard function expressions assigned to variables', () => {
+		const code = `
+            const myFunc = function() {
+                return 'hello';
+            };
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const results = findFunctionExpressions(node);
+
+		expect(results).toHaveLength(1);
+		expect(results[0].kind).toBe(SyntaxKind.FunctionExpression);
+	});
+
+	it('should ignore standard function declarations', () => {
+		const code = `
+            // This is a FunctionDeclaration, not a FunctionExpression assigned to a variable
+            function classicFunction() {
+                return 'I should be ignored';
+            }
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const results = findFunctionExpressions(node);
+
+		expect(results).toHaveLength(0);
+	});
+
+	it('should match nested/inline functions within variables', () => {
+		const code = `
+            const processData = () => {
+                return [1, 2, 3].map(x => x * 2);
+            };
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const results = findFunctionExpressions(node);
+
+		expect(results).toHaveLength(2);
+	});
+});
+
+describe('getSuperClassName()', () => {
+	it('should return the name of the extended base class', () => {
+		const code = `
+            class MyComponent extends BaseComponent {}
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const classNode = node.statements[0];
+
+		expect(getSuperClassName(classNode)).toBe('BaseComponent');
+	});
+
+	it('should return null if the class does not extend anything', () => {
+		const code = `
+            class StandaloneComponent {}
+        `;
+		const node = getAST(code).parsedFile!;
+		const classNode = node.statements[0];
+
+		expect(getSuperClassName(classNode)).toBe(null);
+	});
+
+	it('should NOT return a value from a different class later in the file', () => {
+		const code = `
+            // Class 1: Extends nothing
+            class FirstComponent {}
+
+            // Class 2: Extends something
+            class SecondComponent extends BaseService {}
+        `;
+		const node = getAST(code).parsedFile!;
+
+		// Pass Class 1 to the function
+		const firstClassNode = node.statements[0];
+
+		expect(getSuperClassName(firstClassNode)).toBe(null);
+	});
+
+	it('should ignore "implements" clauses', () => {
+		const code = `
+            class MyComponent implements OnInit, OnDestroy {}
+        `;
+		const node = getAST(code).parsedFile!;
+		const classNode = node.statements[0];
+
+		expect(getSuperClassName(classNode)).toBe(null);
+	});
+});
+
+describe('getStringsFromExpression()', () => {
+	function getExpressionNode(code: string) {
+		const file = getAST(`const target = ${code};`).parsedFile!;
+		const statement = file.statements[0] as VariableStatement;
+		return statement.declarationList.declarations[0].initializer as Expression;
+	}
+
+	describe('Base Extractions', () => {
+		it('should extract a standard string literal', () => {
+			const node = getExpressionNode("'hello_world'");
+			expect(getStringsFromExpression(node)).toEqual(['hello_world']);
+		});
+
+		it('should extract string literals from arrays and ignore empty strings', () => {
+			const node = getExpressionNode("['a', 'b', '', 'c']");
+			expect(getStringsFromExpression(node)).toEqual(['a', 'b', 'c']);
+		});
+	});
+
+	describe('Concatenations (+)', () => {
+		it('should concatenate purely static string segments', () => {
+			const node = getExpressionNode("'hello' + '_' + 'world'");
+			expect(getStringsFromExpression(node)).toEqual(['hello_world']);
+		});
+
+		it('should ignore concatenations that contain dynamic variables', () => {
+			const node = getExpressionNode("'prefix-' + dynamicVariable");
+			expect(getStringsFromExpression(node)).toEqual([]);
+		});
+
+		it('should generate all combinations when concatenating branching logic', () => {
+			const node = getExpressionNode("(isTrue ? 'user_' : 'admin_') + 'profile'");
+			expect(getStringsFromExpression(node)).toEqual(['user_profile', 'admin_profile']);
+		});
+
+		it('should concatenate purely static string segments', () => {
+			const node = getExpressionNode("'hello' + '_' + 'world'");
+			expect(getStringsFromExpression(node)).toEqual(['hello_world']);
+		});
+
+		it('should treat empty string segments as valid parts of a concatenation', () => {
+			const node = getExpressionNode("'' + 'my_class'");
+			expect(getStringsFromExpression(node)).toEqual(['my_class']);
+		});
+
+		it('should preserve whitespace-only segments inside a concatenation', () => {
+			const node = getExpressionNode("'hello' + ' ' + 'world'");
+			expect(getStringsFromExpression(node)).toEqual(['hello world']);
+		});
+
+		it('should ignore concatenations that contain dynamic variables', () => {
+			const node = getExpressionNode("'prefix-' + dynamicVariable");
+			expect(getStringsFromExpression(node)).toEqual([]);
+		});
+	});
+
+	describe('Branching Logic (||, ? :)', () => {
+		it('should extract all possible paths from logical OR operators', () => {
+			const node = getExpressionNode("'primary' || 'fallback'");
+			expect(getStringsFromExpression(node)).toEqual(['primary', 'fallback']);
+		});
+
+		it('should extract all possible paths from ternary operators', () => {
+			const node = getExpressionNode("isTrue ? 'yes' : 'no'");
+			expect(getStringsFromExpression(node)).toEqual(['yes', 'no']);
+		});
+
+		it('should safely flatten nested arrays inside branching logic', () => {
+			const node = getExpressionNode("condition ? ['a', 'b'] : 'c'");
+			expect(getStringsFromExpression(node)).toEqual(['a', 'b', 'c']);
+		});
+	});
+});
+
 describe('getNodesFromSwitchBlockTmpl()', () => {
 	it('should extract nodes from a @switch', () => {
 		const nodes = parseTemplate(
@@ -229,3 +558,716 @@ describe('getNodesFromSwitchBlockTmpl()', () => {
 		expect(childNodes.at(2).children.at(0).value).toBe('switch.default');
 	});
 });
+
+describe('findMethodParameterByType()', () => {
+	it('should return the name of the parameter that matches the specified type', () => {
+		const code = `
+            class MyService {
+                initialize(id: string, config: AppConfig, force: boolean) {
+                    // ...
+                }
+            }
+        `;
+		const node = getClassDeclarationNode(code);
+
+		const result = findMethodParameterByType(node, 'AppConfig');
+
+		expect(result).toBe('config');
+	});
+
+	it('should NOT match parameter names that happen to share the type name', () => {
+		const code = `
+            class MyService {
+                // 'AppConfig' is used as a parameter name for a different type,
+                // while 'validConfig' is the actual parameter we want.
+                setup(AppConfig: LegacyConfig, validConfig: AppConfig) {
+                    // ...
+                }
+            }
+        `;
+		const node = getClassDeclarationNode(code);
+
+		const result = findMethodParameterByType(node, 'AppConfig');
+
+		// It must ignore the trap and return the correct identifier
+		expect(result).toBe('validConfig');
+	});
+
+	it('should return null if the target type does not exist in the parameters', () => {
+		const code = `
+            class MyService {
+                processData(data: string, options: any) {
+                    // ...
+                }
+            }
+        `;
+		const node = getClassDeclarationNode(code);
+
+		const result = findMethodParameterByType(node, 'AppConfig');
+
+		expect(result).toBe(null);
+	});
+});
+
+describe('findVariableNameByInjectType()', () => {
+	it('should return the name of the variable that is assigned the injected type', () => {
+		const code = `
+            function setup() {
+                const myConfig = inject(AppConfig);
+            }
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const result = findVariableNameByInjectType(node, 'AppConfig');
+
+		expect(result).toBe('myConfig');
+	});
+
+	it('should NOT match a variable name that shares the target type name but injects something else', () => {
+		const code = `
+            function setup() {
+                // False positive trap: The variable is named 'AppConfig', but it injects 'LegacyConfig'
+                const AppConfig = inject(LegacyConfig);
+
+                // The actual valid injection
+                const validConfig = inject(AppConfig);
+            }
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const result = findVariableNameByInjectType(node, 'AppConfig');
+
+		// It must ignore the trap and find 'validConfig'
+		expect(result).toBe('validConfig');
+	});
+
+	it('should return null if the type is never injected in a variable declaration', () => {
+		const code = `
+            function setup() {
+                const unrelated = inject(OtherService);
+                let count = 0;
+            }
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const result = findVariableNameByInjectType(node, 'AppConfig');
+
+		expect(result).toBe(null);
+	});
+});
+
+describe('findMethodCallExpressions()', () => {
+	it('should find a call expression matching a specific property and single method name', () => {
+		const code = `
+            function initialize() {
+                // Correct match
+                appConfig.loadEnvironment('prod');
+
+                // Ignored: wrong method name
+                appConfig.clear();
+
+                // Ignored: wrong property name
+                otherConfig.loadEnvironment('dev');
+            }
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const results = findMethodCallExpressions(node, 'appConfig', 'loadEnvironment');
+
+		expect(results).toHaveLength(1);
+		expect(results[0].getText()).toBe("appConfig.loadEnvironment('prod')");
+	});
+
+	it('should find multiple call expressions when provided an array of method names', () => {
+		const code = `
+            function handleRequests() {
+                httpClient.get('/api/data');
+                httpClient.post('/api/data', payload);
+                httpClient.delete('/api/data/1'); // Not in the array, should be ignored
+            }
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const results = findMethodCallExpressions(node, 'httpClient', ['get', 'post']);
+
+		expect(results).toHaveLength(2);
+
+		// Map to string text to easily verify the matched AST nodes
+		const callTexts = results.map((r) => r.getText());
+		expect(callTexts).toContain("httpClient.get('/api/data')");
+		expect(callTexts).toContain("httpClient.post('/api/data', payload)");
+		expect(callTexts).not.toContain("httpClient.delete('/api/data/1')");
+	});
+
+	it('should ignore method calls prefixed with "this."', () => {
+		const code = `
+            class DataService {
+                fetch() {
+                    // False positive trap: ignored because of 'this.'
+                    this.api.requestData();
+
+                    // Valid match: local or injected variable without 'this.'
+                    api.requestData();
+                }
+            }
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const results = findMethodCallExpressions(node, 'api', 'requestData');
+
+		// It must completely ignore `this.api.requestData()` due to the :not(:has(ThisKeyword)) selector
+		expect(results).toHaveLength(1);
+		expect(results[0].getText()).toBe('api.requestData()');
+	});
+});
+
+describe('findInlineInjectCallExpressions()', () => {
+	it('should find a specific method call chained directly to the target injected type', () => {
+		const code = `
+            function initialize() {
+                // Correct match
+                inject(AppConfig).loadEnvironment('prod');
+
+                // Ignored: wrong method name
+                inject(AppConfig).clear();
+
+                // Ignored: wrong injected type
+                inject(OtherConfig).loadEnvironment('dev');
+            }
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const results = findInlineInjectCallExpressions(node, 'AppConfig', 'loadEnvironment');
+
+		expect(results).toHaveLength(1);
+		expect(results[0].getText()).toBe("inject(AppConfig).loadEnvironment('prod')");
+	});
+
+	it('should find multiple method calls when provided an array of function names', () => {
+		const code = `
+            function handleRequests() {
+                inject(HttpClient).get('/api/data');
+                inject(HttpClient).post('/api/data', payload);
+                inject(HttpClient).delete('/api/data/1'); // Not in the array, should be ignored
+            }
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const results = findInlineInjectCallExpressions(node, 'HttpClient', ['get', 'post']);
+
+		expect(results).toHaveLength(2);
+
+		const callTexts = results.map((r) => r.getText());
+		expect(callTexts).toContain("inject(HttpClient).get('/api/data')");
+		expect(callTexts).toContain("inject(HttpClient).post('/api/data', payload)");
+		expect(callTexts).not.toContain("inject(HttpClient).delete('/api/data/1')");
+	});
+
+	it('should ignore standard variable or class property method calls', () => {
+		const code = `
+            class DataService {
+                constructor(private http: HttpClient) {}
+
+                fetch() {
+                    // False positive trap: matches method and type conceptually, but is NOT an inline inject
+                    this.http.get('/api/data');
+
+                    // False positive trap: standard variable
+                    const client = inject(HttpClient);
+                    client.get('/api/data');
+
+                    // Valid match: true inline inject
+                    inject(HttpClient).get('/api/data');
+                }
+            }
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const results = findInlineInjectCallExpressions(node, 'HttpClient', 'get');
+
+		// It must strictly require the `inject(...)` wrapper as part of the call expression chain
+		expect(results).toHaveLength(1);
+		expect(results[0].getText()).toBe("inject(HttpClient).get('/api/data')");
+	});
+});
+
+describe('findClassPropertiesConstructorParameterByType()', () => {
+	it('should find properties defined via constructor parameters with access modifiers', () => {
+		const code = `
+            class MyService {
+                constructor(
+                    private auth: AuthService,
+                    public config: AppConfig,
+                    protected readonly logger: LoggerService
+                ) {}
+            }
+        `;
+		const classNode = getClassDeclarationNode(code);
+
+		// Test basic private modifier
+		expect(findClassPropertiesConstructorParameterByType(classNode, 'AuthService')).toEqual(['auth']);
+
+		// Test multiple modifiers (protected readonly)
+		expect(findClassPropertiesConstructorParameterByType(classNode, 'LoggerService')).toEqual(['logger']);
+	});
+
+	it('should ignore constructor parameters that do NOT have access/readonly modifiers', () => {
+		const code = `
+            class MyService {
+                constructor(
+                    private validService: AuthService,
+
+                    // Not a class property! Just a local constructor variable.
+                    tempData: AuthService,
+
+                    // Not a class property! (no modifier)
+                    mockService: AuthService
+                ) {}
+            }
+        `;
+		const classNode = getClassDeclarationNode(code);
+
+		const results = findClassPropertiesConstructorParameterByType(classNode, 'AuthService');
+
+		// It must only return the one defined as a class property
+		expect(results).toHaveLength(1);
+		expect(results).toEqual(['validService']);
+	});
+
+	it('should NOT match parameter names that happen to share the target type name', () => {
+		const code = `
+            class MyService {
+                constructor(
+                    // False positive trap: named 'AppConfig' but type is 'LegacyConfig'
+                    private AppConfig: LegacyConfig,
+
+                    // The actual valid property
+                    private validConfig: AppConfig
+                ) {}
+            }
+        `;
+		const classNode = getClassDeclarationNode(code);
+
+		const results = findClassPropertiesConstructorParameterByType(classNode, 'AppConfig');
+
+		// It must completely ignore the naming trap
+		expect(results).toHaveLength(1);
+		expect(results).toEqual(['validConfig']);
+	});
+});
+
+describe('findClassPropertiesDeclarationByType()', () => {
+	it('should find all properties matching the exact specified type', () => {
+		const code = `
+            class MyComponent {
+                mainService: TranslateService;
+                fallbackService: TranslateService;
+                unrelated: OtherService;
+            }
+        `;
+		const classDecl = getClassDeclarationNode(code);
+
+		const results = findClassPropertiesDeclarationByType(classDecl, 'TranslateService');
+
+		expect(results).toHaveLength(2);
+		expect(results).toEqual(expect.arrayContaining(['mainService', 'fallbackService']));
+	});
+
+	it('should ignore properties that have the same name as the target type', () => {
+		const code = `
+		  	class MyComponent {
+				// Property name matches AuthService type, but its type is different
+				AuthService: DifferentService;
+
+				// Correct usage
+				validService: AuthService;
+			}
+		`;
+
+		const classDecl = getClassDeclarationNode(code);
+
+		const results = findClassPropertiesDeclarationByType(classDecl as ClassDeclaration, 'AuthService');
+
+		// It should ONLY find 'validService', ignoring 'AuthService'
+		expect(results).toEqual(['validService']);
+		expect(results).not.toContain('AuthService');
+	});
+
+	it('should ignore properties that have the same name as the target type', () => {
+		const code = `
+            class MyComponent {
+                // Possible false positive: Property name matches the target type
+                TranslateService: OtherService;
+
+                // Possible false positive: Type name is a partial match
+                mockLogger: MockTranslateService;
+
+                // The actual valid property
+                validTranslateService: TranslateService;
+            }
+        `;
+		const classDecl = getClassDeclarationNode(code);
+
+		const results = findClassPropertiesDeclarationByType(classDecl, 'TranslateService');
+
+		expect(results).toEqual(['validTranslateService']);
+	});
+
+	it('should find the type even when wrapped in modifiers, unions, or strict initialization', () => {
+		const code = `
+            class MyComponent {
+                // Access modifiers & readonly
+                private readonly loggerA: LoggerService;
+
+                // Union types
+                public loggerB: LoggerService | null;
+
+                // Initialization operator
+                loggerC!: LoggerService;
+            }
+        `;
+		const classDecl = getClassDeclarationNode(code);
+
+		const results = findClassPropertiesDeclarationByType(classDecl, 'LoggerService');
+
+		expect(results).toHaveLength(3);
+		expect(results).toEqual(expect.arrayContaining(['loggerA', 'loggerB', 'loggerC']));
+	});
+
+	it('should ignore arrays, generic wrappers, and generic initializers', () => {
+		const code = `
+            class MyComponent {
+                // Arrays of the requested Type should be ignored
+                public arrayA: TranslateService[];
+                public arrayB: Array<TranslateService>;
+
+                // Generic wrappers of the requested Type should be ignored
+                public wrappedA: Signal<TranslateService>;
+                public wrappedB: ng.Signal<TranslateService>;
+
+                // Initializers containing the target type as a generic should be ignored
+                public initializedProp = createConfig<TranslateService>();
+                readonly signalProp = signal<TranslateService | undefined>();
+
+                // False positive trap: generic wrapper matches, but internal type doesn't
+                public falseTrap: Observable<OtherConfig>;
+
+                // The actual valid properties
+                public validLogger: TranslateService;
+                public namespacedLogger: ngx.TranslateService;
+                public unionLogger: TranslateService | null;
+            }
+        `;
+		const classDecl = getClassDeclarationNode(code);
+
+		const results = findClassPropertiesDeclarationByType(classDecl, 'TranslateService');
+
+		// It must ignore all the traps and only return the exact matches
+		expect(results).toEqual(['validLogger', 'namespacedLogger', 'unionLogger']);
+	});
+});
+
+describe('findClassPropertiesDeclarationByInject()', () => {
+	it('should find properties that are initialized using inject() with the target type', () => {
+		const code = `
+            class MyComponent {
+                // Correct matches
+                private config = inject(AppConfig);
+                public fallback = inject(AppConfig);
+
+                // Ignored: wrong type
+                private logger = inject(LoggerService);
+            }
+        `;
+		const classNode = getClassDeclarationNode(code);
+
+		const results = findClassPropertiesDeclarationByInject(classNode, 'AppConfig');
+
+		expect(results).toHaveLength(2);
+		expect(results).toEqual(expect.arrayContaining(['config', 'fallback']));
+	});
+
+	it('should NOT match property names that happen to share the target type name', () => {
+		const code = `
+            class MyComponent {
+                // False positive trap: Property is named 'AppConfig', but injects 'LegacyConfig'
+                AppConfig = inject(LegacyConfig);
+
+                // The actual valid injection
+                validConfig = inject(AppConfig);
+            }
+        `;
+		const classNode = getClassDeclarationNode(code);
+
+		const results = findClassPropertiesDeclarationByInject(classNode, 'AppConfig');
+
+		// It must ignore the trap and only find 'validConfig'
+		expect(results).toHaveLength(1);
+		expect(results).toEqual(['validConfig']);
+	});
+
+	it('should return an empty array if the type is never injected into a property', () => {
+		const code = `
+            class MyComponent {
+                // Standard property, not injected
+                config: AppConfig;
+
+                // Injected, but wrong type
+                logger = inject(LoggerService);
+            }
+        `;
+		const classNode = getClassDeclarationNode(code);
+
+		const results = findClassPropertiesDeclarationByInject(classNode, 'AppConfig');
+
+		expect(results).toEqual([]);
+	});
+});
+
+describe('findClassPropertiesGetterByType()', () => {
+	it('should find getters that explicitly declare the target return type', () => {
+		const code = `
+            class MyComponent {
+                // Correct match
+                get config(): AppConfig {
+                    return this._config;
+                }
+
+                // Ignored: wrong return type
+                get logger(): LoggerService {
+                    return this._logger;
+                }
+            }
+        `;
+		const classNode = getClassDeclarationNode(code);
+
+		const results = findClassPropertiesGetterByType(classNode, 'AppConfig');
+
+		expect(results).toHaveLength(1);
+		expect(results).toEqual(['config']);
+	});
+
+	it('should NOT match getters that happen to share the target type name', () => {
+		const code = `
+            class MyComponent {
+                // False positive trap 1: Getter is named 'AppConfig', but returns 'LegacyConfig'
+                get AppConfig(): LegacyConfig {
+                    return this._legacy;
+                }
+
+                // The actual valid getter
+                get validConfig(): AppConfig {
+                    return this._config;
+                }
+            }
+        `;
+		const classNode = getClassDeclarationNode(code);
+
+		const results = findClassPropertiesGetterByType(classNode, 'AppConfig');
+
+		// It must ignore the name trap and only find 'validConfig'
+		expect(results).toHaveLength(1);
+		expect(results).toEqual(['validConfig']);
+	});
+
+	it('should NOT match getters that just use the type inside their body logic', () => {
+		const code = `
+            class MyComponent {
+                // False positive trap 2: The body mentions 'AppConfig', but the return type is 'any'
+                get someData(): any {
+                    const temp = inject(AppConfig);
+                    return temp.getData();
+                }
+            }
+        `;
+		const classNode = getClassDeclarationNode(code);
+
+		const results = findClassPropertiesGetterByType(classNode, 'AppConfig');
+
+		// It must ignore the getter entirely since the declared return type is not 'AppConfig'
+		expect(results).toEqual([]);
+	});
+});
+
+describe('findFunctionCallExpressions()', () => {
+	it('should find top-level function calls by name', () => {
+		const code = `
+            function setup() {
+                // Valid matches
+                bootstrapApplication();
+                initialize();
+            }
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const results = findFunctionCallExpressions(node, 'bootstrapApplication');
+
+		expect(results).toHaveLength(1);
+		expect(results[0].getText()).toBe('bootstrapApplication()');
+	});
+
+	it('should support an array of function names using regex', () => {
+		const code = `
+            const a = inject(ServiceA);
+            const b = forwardRef(() => ServiceB);
+            const c = unrelated();
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const results = findFunctionCallExpressions(node, ['inject', 'forwardRef']);
+
+		expect(results).toHaveLength(2);
+		const textResults = results.map((r) => r.getText());
+		expect(textResults).toContain('inject(ServiceA)');
+		expect(textResults).toContain('forwardRef(() => ServiceB)');
+	});
+
+	it('should ignore method calls chained on objects or "this"', () => {
+		const code = `
+            class MyComponent {
+                setup() {
+                    // False positive traps: these are PropertyAccessExpressions
+                    this.inject();
+                    TestBed.inject(ServiceA);
+
+                    // Valid match: top-level
+                    inject(ServiceB);
+                }
+            }
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const results = findFunctionCallExpressions(node, 'inject');
+
+		expect(results).toHaveLength(1);
+		expect(results[0].getText()).toBe('inject(ServiceB)');
+	});
+});
+
+describe('findSimpleCallExpressions()', () => {
+	it('should find both top-level functions AND method calls', () => {
+		const code = `
+            class MyComponent {
+                setup() {
+                    // It should find ALL of these because it is a "simple" query
+                    this.inject();
+                    TestBed.inject(ServiceA);
+                    inject(ServiceB);
+                }
+            }
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const results = findSimpleCallExpressions(node, 'inject');
+
+		expect(results).toHaveLength(3);
+		const textResults = results.map((r) => r.getText());
+		expect(textResults).toContain('this.inject()');
+		expect(textResults).toContain('TestBed.inject(ServiceA)');
+		expect(textResults).toContain('inject(ServiceB)');
+	});
+
+	it('should support finding multiple function names using an array', () => {
+		const code = `
+            function run() {
+                console.log('test');
+                logger.warn('test');
+                alert('test');
+            }
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const results = findSimpleCallExpressions(node, ['log', 'warn']);
+
+		expect(results).toHaveLength(2);
+		const textResults = results.map((r) => r.getText());
+		expect(textResults).toContain("console.log('test')");
+		expect(textResults).toContain("logger.warn('test')");
+	});
+});
+
+describe('findPropertyCallExpressions()', () => {
+	it('should find method calls on a specific class property via "this."', () => {
+		const code = `
+            class MyComponent {
+                constructor(private authService: AuthService) {}
+
+                login() {
+                    // Valid match
+                    this.authService.authenticate();
+
+                    // Ignored: wrong method name
+                    this.authService.logout();
+
+                    // Ignored: wrong property name
+                    this.otherService.authenticate();
+                }
+            }
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const results = findPropertyCallExpressions(node, 'authService', 'authenticate');
+
+		expect(results).toHaveLength(1);
+		expect(results[0].getText()).toBe('this.authService.authenticate()');
+	});
+
+	it('should find multiple method calls when provided an array of function names', () => {
+		const code = `
+            class DataService {
+                constructor(private http: HttpClient) {}
+
+                fetchData() {
+                    // Valid matches
+                    this.http.get('/api/data');
+                    this.http.post('/api/data', payload);
+
+                    // Ignored: not in the array
+                    this.http.delete('/api/data/1');
+                }
+            }
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const results = findPropertyCallExpressions(node, 'http', ['get', 'post']);
+
+		expect(results).toHaveLength(2);
+
+		const callTexts = results.map((r) => r.getText());
+		expect(callTexts).toContain("this.http.get('/api/data')");
+		expect(callTexts).toContain("this.http.post('/api/data', payload)");
+		expect(callTexts).not.toContain("this.http.delete('/api/data/1')");
+	});
+
+	it('should ignore calls that do not use "this." or belong to local variables', () => {
+		const code = `
+            class MyComponent {
+                process() {
+                    // False positive trap: matches property name and method, but lacks "this."
+                    const http = inject(HttpClient);
+                    http.get('/api/data');
+
+                    // Valid match
+                    this.http.get('/api/data');
+                }
+            }
+        `;
+		const node = getAST(code).parsedFile!;
+
+		const results = findPropertyCallExpressions(node, 'http', 'get');
+
+		expect(results).toHaveLength(1);
+		expect(results[0].getText()).toBe("this.http.get('/api/data')");
+	});
+});
+
+function getClassDeclarationNode(code: string): ClassDeclaration {
+	const ast = tsquery.ast(code, 'test.ts', ScriptKind.TS);
+	const classDecl = tsquery.query<ClassDeclaration>(ast, 'ClassDeclaration')[0];
+
+	if (!isClassDeclaration(classDecl)) {
+		throw new Error('No class declaration found');
+	}
+
+	return classDecl;
+}


### PR DESCRIPTION
Benchmarked with vitest bench (1000 keys per parser), compared against the optimization since #156. This PR focuses on optimizing the typescript files AST

| Parser      | Before   | After   | Speedup |
|-------------|----------|---------|---------|
| Service     | 31.41 ms | 0.27 ms | ~117x   |
| TranslateFn | 6.92 ms  | 0.09 ms | ~78x    |
| Marker      | 6.94 ms  | 0.10 ms | ~69x    |
| Function    | 2.88 ms  | 0.11 ms | ~26x    |

Overall Performance compared against the pre-optimization baseline:

| Parser          | Original Baseline | Final Result | Total Speedup |
|--------------|-------------------|--------------|---------------|
| Function     | 79.40 ms          | 0.09 ms      | ~858x         |
| TranslateFn | 82.25 ms         | 0.10 ms      | ~839x         |
| Marker        | 79.95 ms          | 0.10 ms      | ~795x         |
| Directive     | 70.89 ms          | 0.16 ms      | ~446x         |
| Service        | 114.20 ms         | 0.26 ms      | ~435x         |
| Pipe            | 69.71 ms            | 0.47 ms      | ~148x         |


The changes also address the following issues:
- Fix TypeScript parser dropping concatenated string keys containing spaces or empty strings (e.g. `'PREFIX' + ' ' + 'KEY'`)
- Fix class property parser incorrectly treating generic wrappers (e.g. `Signal<TranslateService>`) or array types (`TranslateService[]`) as direct service instances
- Fix component parser attempting to extract keys from unrelated template properties in nested objects or provider configurations (e.g. `providers: [{useValue: {template: '...'}}]`)
- Fix inheritance traversal incorrectly treating `implements` interface clauses as extended base classes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/ngx-translate-extract/pr/159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787340629&installation_model_id=20193&pr_number=159&repository=vendurehq%2Fngx-translate-extract&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fngx-translate-extract%2Fpull%2F159&signature=70968d859cd2dc1291a250e68983783c4bae6197a442b9b5afea77a48fd0b134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->