### PR TITLE
perf(parsers): skip files and parsers that cannot match before parsing

### DIFF
--- a/src/cli/tasks/extract.task.ts
+++ b/src/cli/tasks/extract.task.ts
@@ -122,11 +122,16 @@ export class ExtractTask implements TaskInterface {
 		this.inputs.forEach((pattern) => {
 			this.getFiles(pattern).forEach((filePath) => {
 				const contents: string = fs.readFileSync(filePath, 'utf-8');
+				const applicableParsers = this.parsers.filter((parser) => parser.canMatch?.(contents) ?? true);
+				if (applicableParsers.length === 0) {
+					return;
+				}
+
 				skipped += 1;
 				const cachedCollectionValues = this.cache.get(`${pattern}:${filePath}:${contents}`, () => {
 					skipped -= 1;
 					this.out(dim('- %s'), filePath);
-					return this.parsers
+					return applicableParsers
 						.map((parser) => {
 							const extracted = parser.extract(contents, filePath);
 							return extracted.values;

--- a/src/parsers/directive.parser.ts
+++ b/src/parsers/directive.parser.ts
@@ -42,6 +42,10 @@ export const TRANSLATE_ATTR_NAMES = ['translate', 'marker'];
 type ElementLike = Element | Template;
 
 export class DirectiveParser implements ParserInterface {
+	public canMatch(source: string): boolean {
+		return TRANSLATE_ATTR_NAMES.some((name) => source.includes(name));
+	}
+
 	public extract(source: string, filePath: string): TranslationCollection {
 		const extracted: TranslationType = Object.create(null);
 		const filePathNormalized = normalizeFilePath(filePath);

--- a/src/parsers/function.parser.ts
+++ b/src/parsers/function.parser.ts
@@ -7,8 +7,21 @@ import { toTranslationType } from '../utils/utils.js';
 import { ParserInterface } from './parser.interface.js';
 const { isIdentifier } = pkg;
 
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 export class FunctionParser implements ParserInterface {
-	constructor(private fnName: string) {}
+	private readonly fnNamePattern: RegExp;
+
+	constructor(private fnName: string) {
+		// Whole-identifier match, so a marker named `_` isn't triggered by every `snake_case` or `__dirname`.
+		this.fnNamePattern = new RegExp(`(?<![\\w$])${escapeRegExp(fnName)}(?![\\w$])`);
+	}
+
+	public canMatch(source: string): boolean {
+		return this.fnNamePattern.test(source);
+	}
 
 	public extract(source: string, filePath: string): TranslationCollection {
 		const extracted: TranslationType = Object.create(null);

--- a/src/parsers/marker.parser.ts
+++ b/src/parsers/marker.parser.ts
@@ -12,6 +12,10 @@ const NGX_TRANSLATE_MARKER_MODULE_NAME = '@ngx-translate/core';
 const NGX_TRANSLATE_MARKER_IMPORT_NAME = '_';
 
 export class MarkerParser implements ParserInterface {
+	public canMatch(source: string): boolean {
+		return MARKER_MODULE_NAME.test(source) || source.includes(NGX_TRANSLATE_MARKER_MODULE_NAME);
+	}
+
 	public extract(source: string, filePath: string): TranslationCollection {
 		const extracted: TranslationType = Object.create(null);
 		const filePathNormalized = normalizeFilePath(filePath);

--- a/src/parsers/parser.interface.ts
+++ b/src/parsers/parser.interface.ts
@@ -2,4 +2,11 @@ import { TranslationCollection } from '../utils/translation.collection.js';
 
 export interface ParserInterface {
 	extract(source: string, filePath: string): TranslationCollection;
+
+	/**
+	 * Cheap text check so files this parser cannot possibly extract from are never parsed.
+	 * Must stay conservative: returning false for a file `extract` would have found keys in
+	 * drops those keys silently. When unsure, return true.
+	 */
+	canMatch?(source: string): boolean;
 }

--- a/src/parsers/pipe.parser.ts
+++ b/src/parsers/pipe.parser.ts
@@ -82,6 +82,10 @@ function traverseAstNode<T>(
 }
 
 export class PipeParser implements ParserInterface {
+	public canMatch(source: string): boolean {
+		return TRANSLATE_PIPE_NAMES.some((name) => source.includes(name));
+	}
+
 	public extract(source: string, filePath: string): TranslationCollection {
 		const filePathNormalized = normalizeFilePath(filePath);
 		const parsedTemplates = getAST(source, filePath).parsedTemplates;

--- a/src/parsers/service.parser.ts
+++ b/src/parsers/service.parser.ts
@@ -41,6 +41,10 @@ export class ServiceParser implements ParserInterface {
 	private static propertyMap = new Map<string, string[]>();
 	private static compilerOptionsCache = new Map<string, CompilerOptions>();
 
+	public canMatch(source: string): boolean {
+		return source.includes(TRANSLATE_SERVICE_TYPE_REFERENCE);
+	}
+
 	public extract(source: string, filePath: string): TranslationCollection {
 		const extracted: TranslationType = Object.create(null);
 		const filePathNormalized = normalizeFilePath(filePath);

--- a/src/parsers/translate-function.parser.ts
+++ b/src/parsers/translate-function.parser.ts
@@ -4,7 +4,14 @@ import { TranslationCollection, type TranslationType } from '../utils/translatio
 import { toTranslationType } from '../utils/utils.js';
 import { ParserInterface } from './parser.interface.js';
 
+const TRANSLATE_FN_MODULE_NAME = '@ngx-translate/core';
+const TRANSLATE_FN_IMPORT_NAME = 'translate';
+
 export class TranslateFunctionParser implements ParserInterface {
+	public canMatch(source: string): boolean {
+		return source.includes(TRANSLATE_FN_MODULE_NAME);
+	}
+
 	public extract(source: string, filePath: string): TranslationCollection {
 		const extracted: TranslationType = Object.create(null);
 		const filePathNormalized = normalizeFilePath(filePath);
@@ -14,7 +21,7 @@ export class TranslateFunctionParser implements ParserInterface {
 			return new TranslationCollection();
 		}
 
-		const translateFnImportName = getNamedImportAlias(sourceFile, 'translate', '@ngx-translate/core');
+		const translateFnImportName = getNamedImportAlias(sourceFile, TRANSLATE_FN_IMPORT_NAME, TRANSLATE_FN_MODULE_NAME);
 		if (!translateFnImportName) {
 			return new TranslationCollection();
 		}

--- a/tests/parsers/can-match.spec.ts
+++ b/tests/parsers/can-match.spec.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+
+import { DirectiveParser } from '../../src/parsers/directive.parser.js';
+import { FunctionParser } from '../../src/parsers/function.parser.js';
+import { MarkerParser } from '../../src/parsers/marker.parser.js';
+import { ParserInterface } from '../../src/parsers/parser.interface.js';
+import { PipeParser } from '../../src/parsers/pipe.parser.js';
+import { ServiceParser } from '../../src/parsers/service.parser.js';
+import { TranslateFunctionParser } from '../../src/parsers/translate-function.parser.js';
+
+interface ParserCase {
+	name: string;
+	parser: ParserInterface;
+	filePath: string;
+	/** Sources the parser really does extract from. `canMatch` must accept every one of them. */
+	matching: string[];
+}
+
+const CASES: ParserCase[] = [
+	{
+		name: 'PipeParser',
+		parser: new PipeParser(),
+		filePath: 'test.template.html',
+		matching: [
+			`<p>{{ 'Hello world' | translate }}</p>`,
+			`<p>{{   'odd.spacing'   |   translate   }}</p>`,
+			`<p>{{ 'across.newlines'\n  | translate }}</p>`,
+			`<p>{{ 'via.marker.pipe' | marker }}</p>`,
+		],
+	},
+	{
+		name: 'DirectiveParser',
+		parser: new DirectiveParser(),
+		filePath: 'test.template.html',
+		matching: [`<span translate>Hello world</span>`, `<span [translate]="'bound.key'"></span>`, `<span marker>marker.key</span>`],
+	},
+	{
+		name: 'ServiceParser',
+		parser: new ServiceParser(),
+		filePath: 'test.component.ts',
+		matching: [
+			`
+				import { TranslateService } from '@ngx-translate/core';
+				export class AppComponent {
+					constructor(protected translateService: TranslateService) {
+						translateService.get('constructor.injected');
+					}
+				}
+			`,
+			`
+				import { inject } from '@angular/core';
+				import { TranslateService } from '@ngx-translate/core';
+				export class AppComponent {
+					private translateService = inject(TranslateService);
+					greet() {
+						return this.translateService.instant('inject.form');
+					}
+				}
+			`,
+			`
+				import { TranslateService } from '@ngx-translate/core';
+				export class AppComponent {
+					constructor(protected translateService: TranslateService) {
+						translateService.stream('stream.method');
+					}
+				}
+			`,
+		],
+	},
+	{
+		name: 'MarkerParser',
+		parser: new MarkerParser(),
+		filePath: 'test.component.ts',
+		matching: [
+			`
+				import { marker } from '@biesbjerg/ngx-translate-extract-marker';
+				marker('extract.marker.package');
+			`,
+			`
+				import { _ } from '@ngx-translate/core';
+				_('ngx.translate.marker');
+			`,
+			`
+				import { _ } from '@ngx-translate/core';
+				_
+				('newline.before.paren');
+			`,
+		],
+	},
+	{
+		name: 'TranslateFunctionParser',
+		parser: new TranslateFunctionParser(),
+		filePath: 'test.component.ts',
+		matching: [
+			`
+				import { translate } from '@ngx-translate/core';
+				translate('translate.function');
+			`,
+			`
+				import { translate as t } from '@ngx-translate/core';
+				t('aliased.translate.function');
+			`,
+		],
+	},
+	{
+		name: 'FunctionParser',
+		parser: new FunctionParser('MK'),
+		filePath: 'test.component.ts',
+		matching: [`MK('marker.function');`, `MK ('space.before.paren');`, `MK\n('newline.before.paren');`],
+	},
+];
+
+describe('canMatch', () => {
+	CASES.forEach(({ name, parser, filePath, matching }) => {
+		describe(`${name}`, () => {
+			it('should accept every source it extracts keys from', () => {
+				matching.forEach((source) => {
+					// If this fails the parser is about to be skipped for a file it would have found keys in.
+					expect(parser.extract(source, filePath).keys().length, `expected keys from: ${source}`).to.be.greaterThan(0);
+					expect(parser.canMatch?.(source), `canMatch rejected: ${source}`).to.equal(true);
+				});
+			});
+
+			it('should reject a source with nothing to extract', () => {
+				const source = filePath.endsWith('.html')
+					? `<p>Nothing to see here</p>`
+					: `export const answer = 42;\nconst snake_case_name = '__dirname';`;
+
+				expect(parser.extract(source, filePath).keys()).to.deep.equal([]);
+				expect(parser.canMatch?.(source)).to.equal(false);
+			});
+		});
+	});
+});


### PR DESCRIPTION
Follow-up to #160. This is ideas 1 and 2 from that issue; it doesn't touch `ast-helpers.ts`, so it's independent of #159 and the two compose.

## What

Every file is currently parsed and walked by all six parsers, even when nothing in it could possibly match. A parser can only produce a key if its trigger token is physically present in the source, so `ParserInterface` gains an optional `canMatch(source)` that each parser derives from its own constants:

| Parser | Trigger |
| --- | --- |
| `PipeParser` / `DirectiveParser` | its own `TRANSLATE_*_NAMES` |
| `ServiceParser` | `TRANSLATE_SERVICE_TYPE_REFERENCE` |
| `MarkerParser` | its two module-name constants |
| `TranslateFunctionParser` | `@ngx-translate/core` |
| `FunctionParser` | the configured `fnName`, as a whole identifier |

`ExtractTask` uses it twice: to skip a parser for a given file, and to skip the file entirely when no parser can match. On my repo that's 48% of files skipped outright and 62% of parser runs.

Deriving each check from the parser's own constants is deliberate: a lookup table in `ExtractTask` would silently drift when a parser's constants change.

## Numbers

Measured on 1,803 `.ts`/`.html` files, best user CPU of 3 runs. Output byte-identical in every case (6,495 keys):

| | user CPU |
| --- | ---: |
| master | 22.4s |
| this branch | **6.3s** |
| #159 | 7.6s |
| #159 + this branch | **4.3s** |

I merged #159 into this branch locally to check: no conflicts, all tests pass together.

## Safety

The failure mode is silent, since a `canMatch` that's narrower than its parser drops keys with everything still green. Unit-testing each half separately doesn't catch that, so `tests/parsers/can-match.spec.ts` pins the contract instead: for every source a parser really extracts from, `canMatch` must accept it. Included fixtures cover odd pipe spacing, pipes across newlines, bound `[translate]`, the `marker` alias, `inject()`, the marker package import, and space/newline before the marker's paren.

`canMatch` is optional, so any parser that doesn't implement it just runs as before.

Also worth noting: `FunctionParser` matches its marker as a whole identifier rather than a substring. A `_\s*\(` style check would miss `MK/* comment */('key')`, which is legal TS; matching the identifier has no such hole and still excludes `snake_case` and `__dirname`.

339 tests pass, lint and format clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/ngx-translate-extract/pr/161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787819935&installation_model_id=20193&pr_number=161&repository=vendurehq%2Fngx-translate-extract&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fngx-translate-extract%2Fpull%2F161&signature=faaa777eca829c1d1f3d6c7404e9c941146397c931f779f8aa554c62ee43a0e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->