### PR TITLE
perf(extract): run extraction across worker threads

### DIFF
--- a/src/cache/cache-interface.ts
+++ b/src/cache/cache-interface.ts
@@ -1,4 +1,10 @@
 export interface CacheInterface<RESULT extends object = object> {
 	persist(): void;
 	get<KEY extends string>(uniqueContents: KEY, generator: () => RESULT): RESULT;
+
+	/**
+	 * Whether a value is already cached, so callers can batch the misses before generating them.
+	 * Optional: treat a missing implementation as "always a miss".
+	 */
+	has?<KEY extends string>(uniqueContents: KEY): boolean;
 }

--- a/src/cache/file-cache.ts
+++ b/src/cache/file-cache.ts
@@ -32,6 +32,15 @@ export class FileCache<RESULT extends object = object> implements CacheInterface
 		return (this.tapped[key] = generator());
 	}
 
+	public has<KEY extends string>(uniqueContents: KEY): boolean {
+		if (!this.cached) {
+			this.readCache();
+			this.versionHash = this.getVersionHash();
+		}
+
+		return !!this.cached && getHash(`${this.versionHash}${uniqueContents}`) in this.cached;
+	}
+
 	public persist(): void {
 		const newCache = JSON.stringify(this.sortByKey(this.tapped), null, 2);
 		if (newCache === this.originalCache) {

--- a/src/cache/null-cache.ts
+++ b/src/cache/null-cache.ts
@@ -5,4 +5,7 @@ export class NullCache<RESULT extends object = object> implements CacheInterface
 	get<KEY extends string>(_uniqueContents: KEY, generator: () => RESULT): RESULT {
 		return generator();
 	}
+	has<KEY extends string>(_uniqueContents: KEY): boolean {
+		return false;
+	}
 }

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -226,7 +226,7 @@ extractTask.setCompiler(compiler);
 
 // Run task
 try {
-	extractTask.execute();
+	await extractTask.executeAsync();
 	if (cli.nullAsDefaultValue && cli.format === CompilerType.Pot) {
 		console.log(yellow(`\nWARNING: POT format does not support --null-as-default-value.`));
 	}

--- a/src/cli/tasks/extract.task.ts
+++ b/src/cli/tasks/extract.task.ts
@@ -1,5 +1,7 @@
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
+import { Worker } from 'node:worker_threads';
 
 import { globSync } from 'glob';
 
@@ -12,7 +14,18 @@ import { PostProcessorInterface } from '../../post-processors/post-processor.int
 import { clearAstCache } from '../../utils/ast-helpers.js';
 import { cyan, green, bold, dim, red } from '../../utils/cli-color.js';
 import { TranslationCollection, TranslationType } from '../../utils/translation.collection.js';
+import type { ExtractWorkerData, ExtractWorkItem, ExtractWorkResult } from './extract.worker.js';
+import { ParserDescriptor } from './parser-descriptor.js';
 import { TaskInterface } from './task.interface.js';
+
+interface PendingExtraction {
+	cached: TranslationType[];
+	items: ExtractWorkItem[];
+	skipped: number;
+}
+
+const PARALLEL_FILE_THRESHOLD = 200;
+const MAX_WORKERS = 8;
 
 export interface ExtractTaskOptionsInterface {
 	replace?: boolean;
@@ -44,7 +57,33 @@ export class ExtractTask implements TaskInterface {
 		this.printEnabledCompiler();
 
 		this.out(bold('Extracting:'));
-		const extracted = this.extract();
+		const pending = this.collectPending();
+		this.write(this.collect(pending, this.extractInline(pending.items)));
+	}
+
+	/**
+	 * Same output as `execute`, but spreads parsing across worker threads when there are enough
+	 * files to be worth it. Separate from `execute` so the synchronous signature keeps working.
+	 */
+	public async executeAsync(): Promise<void> {
+		this.printEnabledParsers();
+		this.printEnabledPostProcessors();
+		this.printEnabledCompiler();
+
+		this.out(bold('Extracting:'));
+		const pending = this.collectPending();
+		const descriptors = this.describeParsers();
+		const workerCount = this.resolveWorkerCount(pending.items.length, descriptors);
+
+		const results =
+			workerCount > 1 && descriptors
+				? await this.extractInWorkers(pending.items, workerCount, descriptors)
+				: this.extractInline(pending.items);
+
+		this.write(this.collect(pending, results));
+	}
+
+	protected write(extracted: TranslationCollection): void {
 		this.out(green('\nFound %d strings.\n'), extracted.count());
 
 		this.out(bold('Saving:'));
@@ -114,33 +153,40 @@ export class ExtractTask implements TaskInterface {
 	}
 
 	/**
-	 * Extract strings from specified input dirs using configured parsers
+	 * Reads every input file, answering the cache up front so only misses need parsing.
 	 */
-	protected extract(): TranslationCollection {
-		const collectionTypes: TranslationType[] = [];
+	protected collectPending(): PendingExtraction {
+		const cached: TranslationType[] = [];
+		const items: ExtractWorkItem[] = [];
 		let skipped = 0;
+
 		this.inputs.forEach((pattern) => {
 			this.getFiles(pattern).forEach((filePath) => {
 				const contents: string = fs.readFileSync(filePath, 'utf-8');
-				skipped += 1;
-				const cachedCollectionValues = this.cache.get(`${pattern}:${filePath}:${contents}`, () => {
-					skipped -= 1;
-					this.out(dim('- %s'), filePath);
-					return this.parsers
-						.map((parser) => {
-							const extracted = parser.extract(contents, filePath);
-							return extracted.values;
-						})
-						.filter((result) => Object.keys(result).length > 0);
-				});
+				const cacheKey = `${pattern}:${filePath}:${contents}`;
 
-				collectionTypes.push(...cachedCollectionValues);
-				clearAstCache();
+				if (this.cache.has?.(cacheKey)) {
+					skipped += 1;
+					cached.push(...this.cache.get(cacheKey, () => []));
+					return;
+				}
+
+				items.push({ cacheKey, filePath, contents });
 			});
 		});
 
-		if (skipped) {
-			this.out(dim('- %s unchanged files skipped via cache'), skipped);
+		return { cached, items, skipped };
+	}
+
+	protected collect(pending: PendingExtraction, results: ExtractWorkResult[]): TranslationCollection {
+		const collectionTypes = [...pending.cached];
+		results.forEach(({ cacheKey, filePath, values }) => {
+			this.out(dim('- %s'), filePath);
+			collectionTypes.push(...this.cache.get(cacheKey, () => values));
+		});
+
+		if (pending.skipped) {
+			this.out(dim('- %s unchanged files skipped via cache'), pending.skipped);
 		}
 
 		const values: TranslationType = {};
@@ -149,6 +195,69 @@ export class ExtractTask implements TaskInterface {
 		}
 
 		return new TranslationCollection(values);
+	}
+
+	/**
+	 * Parsers that can't describe themselves (custom implementations) keep extraction on one thread,
+	 * since a worker has no way to rebuild them.
+	 */
+	protected describeParsers(): ParserDescriptor[] | undefined {
+		const descriptors = this.parsers.map((parser) => parser.describe?.());
+		return descriptors.every((descriptor) => !!descriptor) ? (descriptors as ParserDescriptor[]) : undefined;
+	}
+
+	/**
+	 * Workers only pay off once their startup cost is amortised over enough files, and they can
+	 * only be used when the caller supplied a recipe for rebuilding the parsers inside them.
+	 */
+	protected resolveWorkerCount(pendingCount: number, descriptors: ParserDescriptor[] | undefined): number {
+		if (!descriptors || pendingCount < PARALLEL_FILE_THRESHOLD) {
+			return 1;
+		}
+
+		const available = Math.max(1, (os.availableParallelism?.() ?? os.cpus().length) - 1);
+		return Math.max(1, Math.min(available, MAX_WORKERS, Math.floor(pendingCount / PARALLEL_FILE_THRESHOLD)));
+	}
+
+	protected extractInline(items: ExtractWorkItem[]): ExtractWorkResult[] {
+		return items.map(({ cacheKey, filePath, contents }) => {
+			const values = this.parsers
+				.map((parser) => parser.extract(contents, filePath).values)
+				.filter((result) => Object.keys(result).length > 0);
+			clearAstCache();
+			return { cacheKey, filePath, values };
+		});
+	}
+
+	protected extractInWorkers(
+		items: ExtractWorkItem[],
+		workerCount: number,
+		descriptors: ParserDescriptor[],
+	): Promise<ExtractWorkResult[]> {
+		const workerUrl = new URL('./extract.worker.js', import.meta.url);
+		const chunkSize = Math.ceil(items.length / workerCount);
+		const chunks: ExtractWorkItem[][] = [];
+		for (let i = 0; i < items.length; i += chunkSize) {
+			chunks.push(items.slice(i, i + chunkSize));
+		}
+
+		return Promise.all(
+			chunks.map(
+				(chunk) =>
+					new Promise<ExtractWorkResult[]>((resolve, reject) => {
+						const worker = new Worker(workerUrl, {
+							workerData: { descriptors, items: chunk } satisfies ExtractWorkerData,
+						});
+						worker.once('message', resolve);
+						worker.once('error', reject);
+						worker.once('exit', (code) => {
+							if (code !== 0) {
+								reject(new Error(`Extraction worker stopped with exit code ${code}`));
+							}
+						});
+					}),
+			),
+		).then((results) => results.flat());
 	}
 
 	/**

--- a/src/cli/tasks/extract.worker.ts
+++ b/src/cli/tasks/extract.worker.ts
@@ -1,0 +1,33 @@
+import { parentPort, workerData } from 'node:worker_threads';
+
+import { clearAstCache } from '../../utils/ast-helpers.js';
+import { TranslationType } from '../../utils/translation.collection.js';
+import { buildParsers, ParserDescriptor } from './parser-descriptor.js';
+
+export interface ExtractWorkItem {
+	cacheKey: string;
+	filePath: string;
+	contents: string;
+}
+
+export interface ExtractWorkerData {
+	descriptors: ParserDescriptor[];
+	items: ExtractWorkItem[];
+}
+
+export interface ExtractWorkResult {
+	cacheKey: string;
+	filePath: string;
+	values: TranslationType[];
+}
+
+const { descriptors, items } = workerData as ExtractWorkerData;
+const parsers = buildParsers(descriptors);
+
+const results: ExtractWorkResult[] = items.map(({ cacheKey, filePath, contents }) => {
+	const values = parsers.map((parser) => parser.extract(contents, filePath).values).filter((result) => Object.keys(result).length > 0);
+	clearAstCache();
+	return { cacheKey, filePath, values };
+});
+
+parentPort?.postMessage(results);

--- a/src/cli/tasks/parser-descriptor.ts
+++ b/src/cli/tasks/parser-descriptor.ts
@@ -1,0 +1,38 @@
+import { DirectiveParser } from '../../parsers/directive.parser.js';
+import { FunctionParser } from '../../parsers/function.parser.js';
+import { MarkerParser } from '../../parsers/marker.parser.js';
+import { ParserInterface } from '../../parsers/parser.interface.js';
+import { PipeParser } from '../../parsers/pipe.parser.js';
+import { ServiceParser } from '../../parsers/service.parser.js';
+import { TranslateFunctionParser } from '../../parsers/translate-function.parser.js';
+
+/**
+ * Parser instances can't cross a worker boundary, so the task hands workers this recipe
+ * and each one builds its own set.
+ */
+export type ParserDescriptor =
+	| { name: 'pipe' }
+	| { name: 'directive' }
+	| { name: 'service' }
+	| { name: 'translate-function' }
+	| { name: 'marker' }
+	| { name: 'function'; fnName: string };
+
+export function buildParsers(descriptors: ParserDescriptor[]): ParserInterface[] {
+	return descriptors.map((descriptor) => {
+		switch (descriptor.name) {
+			case 'pipe':
+				return new PipeParser();
+			case 'directive':
+				return new DirectiveParser();
+			case 'service':
+				return new ServiceParser();
+			case 'translate-function':
+				return new TranslateFunctionParser();
+			case 'marker':
+				return new MarkerParser();
+			case 'function':
+				return new FunctionParser(descriptor.fnName);
+		}
+	});
+}

--- a/src/parsers/directive.parser.ts
+++ b/src/parsers/directive.parser.ts
@@ -23,6 +23,7 @@ import {
 	TmplAstNode,
 } from '@angular/compiler';
 
+import { ParserDescriptor } from '../cli/tasks/parser-descriptor.js';
 import { getAST, getNodesFromSwitchBlockTmpl } from '../utils/ast-helpers.js';
 import { normalizeFilePath } from '../utils/fs-helpers.js';
 import { TranslationCollection, type TranslationType } from '../utils/translation.collection.js';
@@ -42,6 +43,10 @@ export const TRANSLATE_ATTR_NAMES = ['translate', 'marker'];
 type ElementLike = Element | Template;
 
 export class DirectiveParser implements ParserInterface {
+	public describe(): ParserDescriptor {
+		return { name: 'directive' };
+	}
+
 	public extract(source: string, filePath: string): TranslationCollection {
 		const extracted: TranslationType = Object.create(null);
 		const filePathNormalized = normalizeFilePath(filePath);

--- a/src/parsers/function.parser.ts
+++ b/src/parsers/function.parser.ts
@@ -1,5 +1,6 @@
 import pkg from 'typescript';
 
+import { ParserDescriptor } from '../cli/tasks/parser-descriptor.js';
 import { getStringsFromExpression, findSimpleCallExpressions, getAST } from '../utils/ast-helpers.js';
 import { normalizeFilePath } from '../utils/fs-helpers.js';
 import { TranslationCollection, type TranslationType } from '../utils/translation.collection.js';
@@ -9,6 +10,10 @@ const { isIdentifier } = pkg;
 
 export class FunctionParser implements ParserInterface {
 	constructor(private fnName: string) {}
+
+	public describe(): ParserDescriptor {
+		return { name: 'function', fnName: this.fnName };
+	}
 
 	public extract(source: string, filePath: string): TranslationCollection {
 		const extracted: TranslationType = Object.create(null);

--- a/src/parsers/marker.parser.ts
+++ b/src/parsers/marker.parser.ts
@@ -1,5 +1,6 @@
 import { SourceFile } from 'typescript';
 
+import { ParserDescriptor } from '../cli/tasks/parser-descriptor.js';
 import { getNamedImportAlias, findFunctionCallExpressions, getStringsFromExpression, getAST } from '../utils/ast-helpers.js';
 import { normalizeFilePath } from '../utils/fs-helpers.js';
 import { TranslationCollection, type TranslationType } from '../utils/translation.collection.js';
@@ -12,6 +13,10 @@ const NGX_TRANSLATE_MARKER_MODULE_NAME = '@ngx-translate/core';
 const NGX_TRANSLATE_MARKER_IMPORT_NAME = '_';
 
 export class MarkerParser implements ParserInterface {
+	public describe(): ParserDescriptor {
+		return { name: 'marker' };
+	}
+
 	public extract(source: string, filePath: string): TranslationCollection {
 		const extracted: TranslationType = Object.create(null);
 		const filePathNormalized = normalizeFilePath(filePath);

--- a/src/parsers/parser.interface.ts
+++ b/src/parsers/parser.interface.ts
@@ -1,5 +1,12 @@
+import { ParserDescriptor } from '../cli/tasks/parser-descriptor.js';
 import { TranslationCollection } from '../utils/translation.collection.js';
 
 export interface ParserInterface {
 	extract(source: string, filePath: string): TranslationCollection;
+
+	/**
+	 * Recipe for rebuilding this parser inside a worker thread. Parsers that can't describe
+	 * themselves keep extraction single-threaded rather than being silently left out.
+	 */
+	describe?(): ParserDescriptor;
 }

--- a/src/parsers/pipe.parser.ts
+++ b/src/parsers/pipe.parser.ts
@@ -20,6 +20,7 @@ import {
 	TemplateLiteral,
 } from '@angular/compiler';
 
+import { ParserDescriptor } from '../cli/tasks/parser-descriptor.js';
 import { getAST, getNodesFromSwitchBlockTmpl } from '../utils/ast-helpers.js';
 import { normalizeFilePath } from '../utils/fs-helpers.js';
 import { TranslationCollection, type TranslationType } from '../utils/translation.collection.js';
@@ -82,6 +83,10 @@ function traverseAstNode<T>(
 }
 
 export class PipeParser implements ParserInterface {
+	public describe(): ParserDescriptor {
+		return { name: 'pipe' };
+	}
+
 	public extract(source: string, filePath: string): TranslationCollection {
 		const filePathNormalized = normalizeFilePath(filePath);
 		const parsedTemplates = getAST(source, filePath).parsedTemplates;

--- a/src/parsers/service.parser.ts
+++ b/src/parsers/service.parser.ts
@@ -13,6 +13,7 @@ import {
 	sys,
 } from 'typescript';
 
+import { ParserDescriptor } from '../cli/tasks/parser-descriptor.js';
 import {
 	findClassDeclarations,
 	findClassPropertiesByType,
@@ -40,6 +41,10 @@ const TRANSLATE_SERVICE_METHOD_NAMES = ['get', 'instant', 'stream', 'translate']
 export class ServiceParser implements ParserInterface {
 	private static propertyMap = new Map<string, string[]>();
 	private static compilerOptionsCache = new Map<string, CompilerOptions>();
+
+	public describe(): ParserDescriptor {
+		return { name: 'service' };
+	}
 
 	public extract(source: string, filePath: string): TranslationCollection {
 		const extracted: TranslationType = Object.create(null);

--- a/src/parsers/translate-function.parser.ts
+++ b/src/parsers/translate-function.parser.ts
@@ -1,3 +1,4 @@
+import { ParserDescriptor } from '../cli/tasks/parser-descriptor.js';
 import { getNamedImportAlias, findFunctionCallExpressions, getStringsFromExpression, getAST } from '../utils/ast-helpers.js';
 import { normalizeFilePath } from '../utils/fs-helpers.js';
 import { TranslationCollection, type TranslationType } from '../utils/translation.collection.js';
@@ -5,6 +6,10 @@ import { toTranslationType } from '../utils/utils.js';
 import { ParserInterface } from './parser.interface.js';
 
 export class TranslateFunctionParser implements ParserInterface {
+	public describe(): ParserDescriptor {
+		return { name: 'translate-function' };
+	}
+
 	public extract(source: string, filePath: string): TranslationCollection {
 		const extracted: TranslationType = Object.create(null);
 		const filePathNormalized = normalizeFilePath(filePath);


### PR DESCRIPTION
Idea 3 from #160. Independent of #159 (doesn't touch `ast-helpers.ts`), but it **does** overlap #161 — see "Ordering" below.

## What

Extraction is a sequential `forEach` over files and single-threaded (~106% CPU on a 14-core machine). Files parse independently and only combine at the final merge, so the work parallelises cleanly.

- Cache lookups stay on the main thread and only misses are dispatched, so `FileCache` remains single-threaded and unchanged.
- Parser instances can't cross a worker boundary, so each parser describes itself via an optional `describe()` and workers rebuild their own set from that. A parser that **can't** describe itself (any custom implementation) keeps extraction on one thread rather than being silently left out of the run.
- Workers are only used above a file-count threshold, since below it their startup costs more than the parsing they save. On a 2-core runner this degrades to sequential.

## No breaking changes

`execute()` keeps its synchronous signature and its existing behaviour; `executeAsync()` is a new entry point that the CLI opts into. `TaskInterface` is untouched. Both new interface members are optional:

- `ParserInterface.describe?()`
- `CacheInterface.has?()`, so callers can batch misses before generating them

## Numbers

1,803 `.ts`/`.html` files, best of 3, output byte-identical throughout (6,495 keys).

**Wall clock is the metric that matters here** — parallelism buys wall time by spending more total CPU, so both columns are shown.

| | wall | user CPU |
| --- | ---: | ---: |
| master | 20.68s | 22.2s |
| master + this | **11.33s** | 31.0s |
| #159 | 6.10s | 7.6s |
| #159 + this | **2.69s** | 15.4s |
| #159 + #161 | 3.05s | 4.1s |
| #159 + #161 + this | **2.01s** | 7.8s |

## Where I'd temper expectations

Worth being upfront, since it affects whether this is worth your review time:

- The gain shrinks as the other two land. Against master it's 1.8x; on top of #159 + #161 it's ~1.5x, or about 1 second.
- It costs **~2x total CPU**. On a developer machine with idle cores that's free; on a 2-core CI runner it falls back to sequential and buys nothing, and on 4 cores the win is much smaller than above.
- It's the largest and most invasive of the three ideas: a worker file, chunking, a threshold, a second execute path.

So I'd rate this clearly below #161 on value-per-risk. Happy for it to sit until you've decided on the other two, or to close it if you'd rather not carry worker threads.

## Ordering

This conflicts with #161 (7 files: `extract.task.ts`, `parser.interface.ts`, and the five parsers, since both add methods in the same places). Nothing conflicts with #159.

**If you want #161, merge it first and I'll update this PR to resolve.** I've already done that merge locally to produce the bottom row above, so I know exactly what it takes: keep both members on each parser, and apply the `canMatch` gate in the worker as well as on the main thread. Straightforward, just noisy in a diff.

327 tests pass, lint and format clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/ngx-translate-extract/pr/162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787821964&installation_model_id=20193&pr_number=162&repository=vendurehq%2Fngx-translate-extract&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fngx-translate-extract%2Fpull%2F162&signature=c70787c127d7e27516504adca72362af2bde2db18b912ee179665d1f825d0e7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->