### PR TITLE
fix(extract): deduplicate overlapping input globs and resolve extraction file count

### DIFF
--- a/src/cli/tasks/extract.task.ts
+++ b/src/cli/tasks/extract.task.ts
@@ -118,34 +118,52 @@ export class ExtractTask implements TaskInterface {
 	 */
 	protected extract(): TranslationCollection {
 		const collectionTypes: TranslationType[] = [];
-		let skipped = 0;
-		this.inputs.forEach((pattern) => {
-			this.getFiles(pattern).forEach((filePath) => {
-				const contents: string = fs.readFileSync(filePath, 'utf-8');
-				const applicableParsers = this.parsers.filter((parser) => parser.canMatch?.(contents) ?? true);
-				if (applicableParsers.length === 0) {
-					return;
-				}
+		let skippedUnchanged = 0;
+		let skippedNoMatch = 0;
 
-				skipped += 1;
-				const cachedCollectionValues = this.cache.get(`${pattern}:${filePath}:${contents}`, () => {
-					skipped -= 1;
-					this.out(dim('- %s'), filePath);
-					return applicableParsers
-						.map((parser) => {
-							const extracted = parser.extract(contents, filePath);
-							return extracted.values;
-						})
-						.filter((result) => Object.keys(result).length > 0);
-				});
+		// Deduplicate paths
+		const uniqueFilePaths = new Set<string>();
+		for (const pattern of this.inputs) {
+			for (const filePath of this.getFiles(pattern)) {
+				uniqueFilePaths.add(filePath);
+			}
+		}
 
-				collectionTypes.push(...cachedCollectionValues);
-				clearAstCache();
+		for (const filePath of uniqueFilePaths) {
+			const contents = fs.readFileSync(filePath, 'utf-8');
+			const applicableParsers = this.parsers.filter((parser) => parser.canMatch?.(contents) ?? true);
+
+			if (applicableParsers.length === 0) {
+				skippedNoMatch += 1;
+				continue;
+			}
+
+			const cacheKey = `${filePath}:${contents}`;
+			let isCacheMiss = false;
+
+			const cachedCollectionValues = this.cache.get(cacheKey, () => {
+				isCacheMiss = true;
+				this.out(dim('- %s'), filePath);
+
+				return applicableParsers
+					.map((parser) => parser.extract(contents, filePath).values)
+					.filter((result) => Object.keys(result).length > 0);
 			});
-		});
 
-		if (skipped) {
-			this.out(dim('- %s unchanged files skipped via cache'), skipped);
+			if (!isCacheMiss) {
+				skippedUnchanged += 1;
+			}
+
+			collectionTypes.push(...cachedCollectionValues);
+			clearAstCache();
+		}
+
+		if (skippedUnchanged > 0) {
+			this.out(dim('- %s unchanged files skipped via cache'), skippedUnchanged);
+		}
+
+		if (skippedNoMatch > 0) {
+			this.out(dim('- %s files skipped (no matching parser)'), skippedNoMatch);
 		}
 
 		const values: TranslationType = {};

--- a/tests/cli/cli.spec.ts
+++ b/tests/cli/cli.spec.ts
@@ -53,6 +53,21 @@ describe.concurrent('CLI Integration Tests', () => {
 		expect(stdout).toContain('Done.');
 	});
 
+	test('deduplicates overlapping input patterns to log marker fixture exactly once', async ({ expect }) => {
+		const OUTPUT_FILE = createUniqueFileName('dedupe-strings.json');
+
+		const { stdout } = await execAsync(
+			`node ${CLI_PATH} --input ${FIXTURES_PATH} --input ${FIXTURES_PATH} --output ${OUTPUT_FILE} --format=json`,
+		);
+
+		const cleanStdout = stripAnsi(stdout);
+
+		const exactLineRegex = /^\s*-\s*.*[/\\]marker\.fixture\.ts\r?$/gm;
+		const occurrences = (cleanStdout.match(exactLineRegex) || []).length;
+
+		expect(occurrences).toBe(1);
+	});
+
 	test('extracts translation keys to a .json file', async ({ expect }) => {
 		const OUTPUT_FILE = createUniqueFileName('strings.json');
 		await execAsync(`node ${CLI_PATH} --input ${FIXTURES_PATH} --output ${OUTPUT_FILE} --format=json`);
@@ -109,3 +124,11 @@ describe.concurrent('CLI Integration Tests', () => {
 		expect(stdout).toContain('WARNING: POT format does not support --null-as-default-value.');
 	});
 });
+
+/**
+ * Removes ANSI escape codes (colors, dim, formatting) from terminal output.
+ */
+function stripAnsi(input: string): string {
+	/* oxlint-disable no-control-regex */
+	return input.replace(/\u001b\[[0-9;]*m/g, '');
+}


### PR DESCRIPTION
- Deduplicate file paths to eliminate redundant disk I/O and duplicated AST allocations.
- Better resolve extraction file count

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/ngx-translate-extract/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788979402&installation_model_id=20193&pr_number=163&repository=vendurehq%2Fngx-translate-extract&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fngx-translate-extract%2Fpull%2F163&signature=34353b0569124e1b5d4d2d4752d790acb652e7a1bdf058dbca48cd3e5e89882e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->