### PR TITLE
fix(extract): log skipped files with no applicable parser

### DIFF
--- a/src/cli/tasks/extract.task.ts
+++ b/src/cli/tasks/extract.task.ts
@@ -118,8 +118,8 @@ export class ExtractTask implements TaskInterface {
 	 */
 	protected extract(): TranslationCollection {
 		const collectionTypes: TranslationType[] = [];
+		const skippedNoMatch: string[] = [];
 		let skippedUnchanged = 0;
-		let skippedNoMatch = 0;
 
 		// Deduplicate paths
 		const uniqueFilePaths = new Set<string>();
@@ -134,7 +134,7 @@ export class ExtractTask implements TaskInterface {
 			const applicableParsers = this.parsers.filter((parser) => parser.canMatch?.(contents) ?? true);
 
 			if (applicableParsers.length === 0) {
-				skippedNoMatch += 1;
+				skippedNoMatch.push(filePath);
 				continue;
 			}
 
@@ -162,8 +162,10 @@ export class ExtractTask implements TaskInterface {
 			this.out(dim('- %s unchanged files skipped via cache'), skippedUnchanged);
 		}
 
-		if (skippedNoMatch > 0) {
-			this.out(dim('- %s files skipped (no matching parser)'), skippedNoMatch);
+		if (skippedNoMatch.length > 0) {
+			const fileCount = skippedNoMatch.length === 1 ? '1 file' : `${skippedNoMatch.length} files`;
+			this.out(dim(`\nSkipped ${fileCount} (no applicable parser):`));
+			skippedNoMatch.forEach((filePath) => this.out(dim(`- ${filePath}`)));
 		}
 
 		const values: TranslationType = {};


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/ngx-translate-extract/pr/165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788986253&installation_model_id=20193&pr_number=165&repository=vendurehq%2Fngx-translate-extract&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fngx-translate-extract%2Fpull%2F165&signature=0de7f53b5c90d5b57d6d54145fe375813cb784f45cf70bed8e9b40853763e6ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->