### PR TITLE
perf(fs-helpers): optimize path normalization throughput and remove redundant syscalls

### DIFF
--- a/src/utils/fs-helpers.ts
+++ b/src/utils/fs-helpers.ts
@@ -1,8 +1,12 @@
-import * as fs from 'node:fs';
+import { statSync } from 'node:fs';
 import * as os from 'node:os';
 import { basename, sep, posix } from 'node:path';
+import { cwd } from 'node:process';
 
 import braces from 'braces';
+
+const CWD = cwd();
+const CWD_BASENAME = CWD ? basename(CWD) : '';
 
 export function normalizeHomeDir(path: string): string {
 	if (path.substring(0, 1) === '~') {
@@ -16,20 +20,21 @@ export function normalizeHomeDir(path: string): string {
  * with its base name and converting path separators to POSIX style.
  */
 export function normalizeFilePath(filePath: string): string {
-	const cwd = 'process' in globalThis ? process.cwd() : '';
-	const cwdBaseName = basename(cwd);
-
-	if (!filePath.startsWith(cwd)) {
+	if (!CWD || !filePath.startsWith(CWD)) {
 		return filePath;
 	}
 
-	return filePath.replace(cwd, cwdBaseName).replaceAll(sep, posix.sep);
+	return filePath.replace(CWD, CWD_BASENAME).replaceAll(sep, posix.sep);
 }
 
 /**
  * Expands a pattern with braces, handling Windows-style separators.
  */
 export function expandPattern(pattern: string): string[] {
+	if (!pattern.includes('{') || !pattern.includes('}')) {
+		return [pattern];
+	}
+
 	const isWindows = sep === '\\';
 
 	// Windows escaped separators can cause the brace "{" in the pattern to be also escaped and ignored by braces lib.
@@ -45,17 +50,31 @@ export function expandPattern(pattern: string): string[] {
 }
 
 export function normalizePaths(patterns: string[], defaultPatterns: string[] = []): string[] {
-	return patterns
-		.map((pattern) =>
-			expandPattern(pattern)
-				.map((path) => {
-					path = normalizeHomeDir(path);
-					if (fs.existsSync(path) && fs.statSync(path).isDirectory()) {
-						return defaultPatterns.map((defaultPattern) => path + defaultPattern);
-					}
-					return path;
-				})
-				.flat(),
-		)
-		.flat();
+	return patterns.flatMap((pattern) =>
+		expandPattern(pattern).flatMap((path) => {
+			const normalizedPath = normalizeHomeDir(path);
+			if (isDirectorySync(normalizedPath)) {
+				return defaultPatterns.map((defaultPattern) => normalizedPath + defaultPattern);
+			}
+			return normalizedPath;
+		}),
+	);
+}
+
+/** Checks if a path exists and is a directory in a single syscall. */
+export function isDirectorySync(path: string): boolean {
+	try {
+		return statSync(path, { throwIfNoEntry: false })?.isDirectory() ?? false;
+	} catch (error) {
+		// `throwIfNoEntry` only suppresses ENOENT. If an intermediate segment is a file
+		// (e.g. a glob pattern like `dist/bundle.js/*.map`), stat throws ENOTDIR.
+		// This definitively means "not a directory", so we return false and let the
+		// pattern fall through to glob (which yields no matches) matching the previous
+		// existsSync-based behavior. Unresolvable errors propagate.
+		if (error !== null && typeof error === 'object' && 'code' in error && error.code === 'ENOTDIR') {
+			return false;
+		}
+
+		throw error;
+	}
 }

--- a/tests/utils/fs-helpers.spec.ts
+++ b/tests/utils/fs-helpers.spec.ts
@@ -1,22 +1,33 @@
+import * as fs from 'node:fs';
 import * as path from 'node:path';
+import * as process from 'node:process';
 
 import { afterEach, beforeEach, describe, it, expect, vi, MockInstance } from 'vitest';
 
-import { expandPattern, normalizeFilePath } from '../../src/utils/fs-helpers';
+import { expandPattern, isDirectorySync, normalizeFilePath, normalizePaths } from '../../src/utils/fs-helpers.js';
 
 vi.mock('node:path', async (importOriginal) => ({
 	...(await importOriginal<typeof import('node:path')>()),
 	sep: '/',
 }));
 
+vi.mock('node:fs', async (importOriginal) => ({
+	...(await importOriginal<typeof import('node:fs')>()),
+	statSync: vi.fn<(path: string) => Partial<fs.Stats>>(),
+}));
+
+vi.mock('node:os', async (importOriginal) => ({
+	...(await importOriginal<typeof import('node:os')>()),
+	homedir: vi.fn<() => string>(() => '/home/user'),
+}));
+
+vi.mock('node:process', async (importOriginal) => ({
+	...(await importOriginal<typeof import('node:process')>()),
+	cwd: vi.fn<() => string>(() => '/home/user/project'),
+}));
+
 describe('normalizeFilePath', () => {
-	let processCwdMock: MockInstance<() => string>;
-
 	beforeEach(() => {
-		processCwdMock = vi.spyOn(process, 'cwd').mockReturnValue('/home/user/project');
-	});
-
-	afterEach(() => {
 		vi.restoreAllMocks();
 	});
 
@@ -28,13 +39,17 @@ describe('normalizeFilePath', () => {
 		expect(normalizeFilePath('/another/path/src/file.ts')).toBe('/another/path/src/file.ts');
 	});
 
-	it('should handle Windows-style paths correctly', () => {
-		processCwdMock.mockReturnValue('C:\\Users\\User\\project');
+	it('should handle Windows-style paths correctly', async () => {
+		vi.resetModules();
 		// The path.basename method in Node.js is platform-aware which means that when it's called on
 		// Linux, path.basename may interpret C:\\Users\\User\\project as a full path rather than just
 		// a directory.
 		vi.spyOn(path, 'basename').mockImplementation((path: string) => path.split('\\').pop() ?? '');
 		vi.spyOn(path, 'sep', 'get').mockReturnValue('\\');
+		vi.spyOn(process, 'cwd').mockReturnValue('C:\\Users\\User\\project');
+		// Dynamically import module so top-level constants evaluate against the spies
+		const { normalizeFilePath } = await import('../../src/utils/fs-helpers.js');
+
 		expect(normalizeFilePath('C:\\Users\\User\\project\\src\\file.ts')).toBe('project/src/file.ts');
 	});
 
@@ -53,5 +68,102 @@ describe('expandPattern', () => {
 		vi.spyOn(path, 'sep', 'get').mockReturnValue('\\');
 		const result = expandPattern('C:\\Users\\User\\dir\\{en,fr,de}.json');
 		expect(result).toEqual(['C:\\Users\\User\\dir\\en.json', 'C:\\Users\\User\\dir\\fr.json', 'C:\\Users\\User\\dir\\de.json']);
+		vi.restoreAllMocks();
+	});
+});
+
+describe('normalizePaths', () => {
+	let statSyncMock: MockInstance<typeof fs.statSync>;
+
+	beforeEach(() => {
+		statSyncMock = vi.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => false } as fs.Stats);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('should return file paths unchanged', () => {
+		expect(normalizePaths(['/some/file.json'])).toEqual(['/some/file.json']);
+	});
+
+	it('should expand brace patterns', () => {
+		expect(normalizePaths(['/some/{en,fr}.json'])).toEqual(['/some/en.json', '/some/fr.json']);
+	});
+
+	it('should append each default pattern when path is a directory', () => {
+		statSyncMock.mockReturnValue({ isDirectory: () => true } as fs.Stats);
+		expect(normalizePaths(['/some/dir'], ['/*.json', '/*.ts'])).toEqual(['/some/dir/*.json', '/some/dir/*.ts']);
+	});
+
+	it('should return no entries for a directory when defaultPatterns is empty', () => {
+		statSyncMock.mockReturnValue({ isDirectory: () => true } as fs.Stats);
+		expect(normalizePaths(['/some/dir'])).toEqual([]);
+	});
+
+	it('should handle a mix of files and directories across multiple patterns', () => {
+		statSyncMock
+			.mockReturnValueOnce({ isDirectory: () => true } as fs.Stats)
+			.mockReturnValueOnce({ isDirectory: () => false } as fs.Stats);
+		expect(normalizePaths(['/some/dir', '/some/file.json'], ['/*.json'])).toEqual(['/some/dir/*.json', '/some/file.json']);
+	});
+
+	it('should re-throw errors that are not ENOENT', () => {
+		const error = Object.assign(new Error('Permission denied'), { code: 'EACCES' });
+		statSyncMock.mockImplementation(() => {
+			throw error;
+		});
+		expect(() => normalizePaths(['/restricted/file.json'])).toThrow(error);
+	});
+});
+
+describe('isDirectorySync', () => {
+	let statSyncMock: MockInstance<typeof fs.statSync>;
+
+	beforeEach(() => {
+		statSyncMock = vi.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => false } as fs.Stats);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('should return true when the path is a directory', () => {
+		statSyncMock.mockReturnValue({ isDirectory: () => true } as fs.Stats);
+
+		expect(isDirectorySync('src/components')).toBe(true);
+	});
+
+	it('should return false when the path is a file (not a directory)', () => {
+		statSyncMock.mockReturnValue({ isDirectory: () => false } as fs.Stats);
+
+		expect(isDirectorySync('src/index.ts')).toBe(false);
+	});
+
+	it('should return false when the path does not exist', () => {
+		// When `throwIfNoEntry: false` is used, Node.js returns undefined for ENOENT.
+		statSyncMock.mockReturnValue(undefined);
+
+		expect(isDirectorySync('missing/folder')).toBe(false);
+	});
+
+	it('should return false when statSync throws ENOTDIR (path segment is a file)', () => {
+		const error = Object.assign(new Error('Not a directory'), { code: 'ENOTDIR' });
+		statSyncMock.mockImplementation(() => {
+			throw error;
+		});
+
+		const testPath = 'dist/bundle.js/*.map';
+		expect(isDirectorySync(testPath)).toBe(false);
+	});
+
+	it('should re-throw errors that are not ENOTDIR (e.g., EACCES)', () => {
+		const error = Object.assign(new Error('Permission denied'), { code: 'EACCES' });
+		statSyncMock.mockImplementation(() => {
+			throw error;
+		});
+
+		const testPath = '/restricted/secret-folder';
+		expect(() => isDirectorySync(testPath)).toThrow(error);
 	});
 });


### PR DESCRIPTION
- Cache `process.cwd()` at module evaluation to eliminate repeated syscalls
- Add an early return check in `expandPattern` to bypass `braces` AST parser overhead
- Replace `existsSync` + `statSync` double-check with single `statSync({ throwIfNoEntry: false })` call
- Use native `.flatMap()` instead of nested `.map().flat()`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/ngx-translate-extract/pr/166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789327433&installation_model_id=20193&pr_number=166&repository=vendurehq%2Fngx-translate-extract&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fngx-translate-extract%2Fpull%2F166&signature=f7ed352cebe8b7b1ffc5000514c4c6913073dd4fdc9845e8943b19886ec7215b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->